### PR TITLE
Feature/splithttp

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,6 +1,6 @@
 package=boost
 $(package)_version=1_64_0
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.64.0/source/
+$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,6 +1,6 @@
 PACKAGE=qt
 $(package)_version=5.9.6
-$(package)_download_path=https://download.qt.io/official_releases/qt/5.9/$($(package)_version)/submodules
+$(package)_download_path=https://download.qt.io/archive/qt/5.9/$($(package)_version)/submodules
 $(package)_suffix=opensource-src-$($(package)_version).tar.xz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=eed620cb268b199bd83b3fc6a471c51d51e1dc2dbb5374fc97a0cc75facbe36f

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -32,6 +32,7 @@ rpcallowip=127.0.0.1/24         # for access from only localhost
 rpcallowip=192.168.0.0/0        # for access from local network
 
 rpcport=37071
+publicrpcport=38081
 rpcuser=<RPC_LOGIN>
 rpcpassword=<RPC_PASSWORD>
 -----

--- a/doc/man/pocketcoin-cli.1
+++ b/doc/man/pocketcoin-cli.1
@@ -61,6 +61,10 @@ Password for JSON\-RPC connections
 .IP
 Connect to JSON\-RPC on <port> (default: 37071 or testnet: 11011)
 .HP
+\fB\-publicrpcport=\fR<port>
+.IP
+Listen for public JSON\-RPC requests on <port> (default: 38081)
+.HP
 \fB\-rpcuser=\fR<user>
 .IP
 Username for JSON\-RPC connections

--- a/doc/man/pocketcoin-cli.1
+++ b/doc/man/pocketcoin-cli.1
@@ -59,11 +59,12 @@ Password for JSON\-RPC connections
 .HP
 \fB\-rpcport=\fR<port>
 .IP
-Connect to JSON\-RPC on <port> (default: 37071 or testnet: 11011)
+Connect to JSON\-RPC on <port> (default: 37071 or testnet: 36061)
 .HP
 \fB\-publicrpcport=\fR<port>
 .IP
-Listen for public JSON\-RPC requests on <port> (default: 38081)
+Listen for public JSON\-RPC requests on <port> (default: 38081 or
+testnet: 39091)
 .HP
 \fB\-rpcuser=\fR<user>
 .IP

--- a/doc/man/pocketcoin-qt.1
+++ b/doc/man/pocketcoin-qt.1
@@ -559,6 +559,10 @@ Password for JSON\-RPC connections
 Listen for JSON\-RPC connections on <port> (default: 37071 or testnet:
 11011)
 .HP
+\fB\-publicrpcport=\fR<port>
+.IP
+Listen for public JSON\-RPC connections on <port> (default: 38081)
+.HP
 \fB\-rpcserialversion\fR
 .IP
 Sets the serialization of raw transaction or block hex returned in

--- a/doc/man/pocketcoind.1
+++ b/doc/man/pocketcoind.1
@@ -560,6 +560,10 @@ Password for JSON\-RPC connections
 Listen for JSON\-RPC connections on <port> (default: 37071 or testnet:
 11011)
 .HP
+\fB\-publicrpcport=\fR<port>
+.IP
+Listen for public JSON\-RPC connections on <port> (default: 38081)
+.HP
 \fB\-rpcserialversion\fR
 .IP
 Sets the serialization of raw transaction or block hex returned in

--- a/doc/public_access.md
+++ b/doc/public_access.md
@@ -29,7 +29,8 @@
     listen=1
     wsuse=1
     port=37070
-    rpcport=38081
+    rpcport=37071
+    publicrpcport=38081
     wsport=8087
     
     rpcthreads=1

--- a/share/examples/pocketcoin.conf
+++ b/share/examples/pocketcoin.conf
@@ -112,6 +112,9 @@
 # Listen for RPC connections on this TCP port:
 #rpcport=37071
 
+# Listen for public RPC connections on this TCP port:
+#publicrpcport=38081
+
 # You can use Pocketcoin or pocketcoind to send commands to Pocketcoin/pocketcoind
 # running on another host using this option:
 #rpcconnect=127.0.0.1

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -33,11 +33,17 @@ const CBaseChainParams& BaseParams()
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
-        return MakeUnique<CBaseChainParams>("", 37071);
+        return MakeUnique<CBaseChainParams>("", 37071, 38081);
     else if (chain == CBaseChainParams::TESTNET)
+<<<<<<< HEAD
         return MakeUnique<CBaseChainParams>("testnet3", 36061);
     else if (chain == CBaseChainParams::REGTEST)
         return MakeUnique<CBaseChainParams>("regtest", 11011);
+=======
+        return MakeUnique<CBaseChainParams>("testnet3", 11011, 12021);
+    else if (chain == CBaseChainParams::REGTEST)
+        return MakeUnique<CBaseChainParams>("regtest", 36061, 39091);
+>>>>>>> Add -publicrpcport parameter to specify port for public RPC requests
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -35,15 +35,9 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
     if (chain == CBaseChainParams::MAIN)
         return MakeUnique<CBaseChainParams>("", 37071, 38081);
     else if (chain == CBaseChainParams::TESTNET)
-<<<<<<< HEAD
-        return MakeUnique<CBaseChainParams>("testnet3", 36061);
+        return MakeUnique<CBaseChainParams>("testnet3", 36061, 39091);
     else if (chain == CBaseChainParams::REGTEST)
-        return MakeUnique<CBaseChainParams>("regtest", 11011);
-=======
-        return MakeUnique<CBaseChainParams>("testnet3", 11011, 12021);
-    else if (chain == CBaseChainParams::REGTEST)
-        return MakeUnique<CBaseChainParams>("regtest", 36061, 39091);
->>>>>>> Add -publicrpcport parameter to specify port for public RPC requests
+        return MakeUnique<CBaseChainParams>("regtest", 11011, 12021);
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -23,12 +23,16 @@ public:
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
+    int PublicRPCPort() const { return nPublicRPCPort; }
 
     CBaseChainParams() = delete;
-    CBaseChainParams(const std::string& data_dir, int rpc_port) : nRPCPort(rpc_port), strDataDir(data_dir) {}
+    CBaseChainParams(const std::string& data_dir, int rpc_port, int rpc_pub_port) : nRPCPort(rpc_port),
+                                                                                    nPublicRPCPort(rpc_pub_port),
+                                                                                    strDataDir(data_dir) {}
 
 private:
     int nRPCPort;
+    int nPublicRPCPort;
     std::string strDataDir;
 };
 

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -300,7 +300,7 @@ bool StartHTTPRPC()
         return false;
 
     g_socket->RegisterHTTPHandler("/", true, HTTPReq_JSONRPC);
-    g_postSocket->RegisterHTTPHandler("/post/", true, HTTPReq_JSONRPC_Anonymous);
+    g_pubSocket->RegisterHTTPHandler("/post/", true, HTTPReq_JSONRPC_Anonymous);
     g_pubSocket->RegisterHTTPHandler("/public/", true, HTTPReq_JSONRPC_Anonymous);
     if (g_wallet_init_interface.HasWalletSupport()) {
         g_socket->RegisterHTTPHandler("/wallet/", false, HTTPReq_JSONRPC);
@@ -321,7 +321,7 @@ void StopHTTPRPC()
 {
     LogPrint(BCLog::RPC, "Stopping HTTP RPC server\n");
     g_socket->UnregisterHTTPHandler("/", true);
-    g_postSocket->UnregisterHTTPHandler("/post/", true);
+    g_pubSocket->UnregisterHTTPHandler("/post/", true);
     g_pubSocket->UnregisterHTTPHandler("/public/", true);
     if (g_wallet_init_interface.HasWalletSupport()) {
         g_socket->UnregisterHTTPHandler("/wallet/", false);

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -299,11 +299,11 @@ bool StartHTTPRPC()
     if (!InitRPCAuthentication())
         return false;
 
-    RegisterHTTPHandler("/", true, HTTPReq_JSONRPC);
-    RegisterHTTPHandler("/post/", true, HTTPReq_JSONRPC_Anonymous);
-    RegisterHTTPHandler("/public/", true, HTTPReq_JSONRPC_Anonymous);
+    g_socket->RegisterHTTPHandler("/", true, HTTPReq_JSONRPC);
+    g_postSocket->RegisterHTTPHandler("/post/", true, HTTPReq_JSONRPC_Anonymous);
+    g_pubSocket->RegisterHTTPHandler("/public/", true, HTTPReq_JSONRPC_Anonymous);
     if (g_wallet_init_interface.HasWalletSupport()) {
-        RegisterHTTPHandler("/wallet/", false, HTTPReq_JSONRPC);
+        g_socket->RegisterHTTPHandler("/wallet/", false, HTTPReq_JSONRPC);
     }
     struct event_base* eventBase = EventBase();
     assert(eventBase);
@@ -320,11 +320,11 @@ void InterruptHTTPRPC()
 void StopHTTPRPC()
 {
     LogPrint(BCLog::RPC, "Stopping HTTP RPC server\n");
-    UnregisterHTTPHandler("/", true);
-    UnregisterHTTPHandler("/post/", true);
-    UnregisterHTTPHandler("/public/", true);
+    g_socket->UnregisterHTTPHandler("/", true);
+    g_postSocket->UnregisterHTTPHandler("/post/", true);
+    g_pubSocket->UnregisterHTTPHandler("/public/", true);
     if (g_wallet_init_interface.HasWalletSupport()) {
-        UnregisterHTTPHandler("/wallet/", false);
+        g_socket->UnregisterHTTPHandler("/wallet/", false);
     }
     if (httpRPCTimerInterface) {
         RPCUnsetTimerInterface(httpRPCTimerInterface.get());

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -342,8 +342,8 @@ static bool HTTPBindAddresses()
     // Determine what addresses to bind to
     if (!gArgs.IsArgSet("-rpcallowip"))
     { // Default to loopback if not allowing external IPs
-        g_pubSocket->BindAddress("::1", pubicPort);
-        g_pubSocket->BindAddress("127.0.0.1", pubicPort);
+        g_pubSocket->BindAddress("::1", publicPort);
+        g_pubSocket->BindAddress("127.0.0.1", publicPort);
         g_socket->BindAddress("::1", securePort);
         g_socket->BindAddress("127.0.0.1", securePort);
         if (gArgs.IsArgSet("-rpcbind"))
@@ -356,14 +356,14 @@ static bool HTTPBindAddresses()
         for (const std::string &strRPCBind : gArgs.GetArgs("-rpcbind"))
         {
             std::string host;
-            SplitHostPort(strRPCBind, pubicPort, host);
-            g_pubSocket->BindAddress(host, pubicPort);
+            SplitHostPort(strRPCBind, publicPort, host);
+            g_pubSocket->BindAddress(host, publicPort);
             g_socket->BindAddress(host, securePort);
         }
     } else
     { // No specific bind address specified, bind to any
-        g_pubSocket->BindAddress("::", pubicPort);
-        g_pubSocket->BindAddress("0.0.0.0", pubicPort);
+        g_pubSocket->BindAddress("::", publicPort);
+        g_pubSocket->BindAddress("0.0.0.0", publicPort);
         g_socket->BindAddress("::", securePort);
         g_socket->BindAddress("0.0.0.0", securePort);
     }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -612,7 +612,6 @@ void HTTPSocket::InterruptHTTPSocket()
 
 void HTTPSocket::BindAddress(string ipAddr, int port)
 { 
-    // Bind address
     LogPrint(BCLog::HTTP, "Binding RPC on address %s port %i\n", ipAddr, port);
     evhttp_bound_socket *bind_handle = evhttp_bind_socket_with_handle(m_eventHTTP,
         ipAddr.empty() ? nullptr : ipAddr.c_str(), port);

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -171,6 +171,9 @@ HTTPSocket *g_socket;
 HTTPSocket *g_pubSocket;
 HTTPSocket *g_postSocket;
 
+std::thread threadHTTP;
+std::future<bool> threadResult;
+
 /** Check if a network address is allowed to access the HTTP server */
 static bool ClientAllowed(const CNetAddr &netaddr)
 {
@@ -331,26 +334,6 @@ static bool ThreadHTTP(struct event_base *base)
     return event_base_got_break(base) == 0;
 }
 
-void HTTPSocket::BindAddress(string ipAddr, int port)
-{ 
-    // Bind address
-    LogPrint(BCLog::HTTP, "Binding RPC on address %s port %i\n", ipAddr, port);
-    evhttp_bound_socket *bind_handle = evhttp_bind_socket_with_handle(m_eventHTTP,
-        ipAddr.empty() ? nullptr : ipAddr.c_str(), port);
-    if (bind_handle)
-    {
-        m_boundSockets.push_back(bind_handle);
-    } else
-    {
-        LogPrint(BCLog::HTTP,"Binding RPC on address %s port %i failed.\n", ipAddr, port);
-    }
-}
-
-int HTTPSocket::GetAddressCount()
-{
-    return m_boundSockets.size();
-}
-
 /** Bind HTTP server to specified addresses */
 static bool HTTPBindAddresses()
 {
@@ -402,44 +385,6 @@ static void libevent_log_cb(int severity, const char *msg)
         LogPrintf("libevent: %s\n", msg);
     else
         LogPrint(BCLog::LIBEVENT, "libevent: %s\n", msg);
-}
-
-HTTPSocket::HTTPSocket(struct event_base *base, int timeout, int queueDepth)
-{
-#ifdef WIN32
-    evthread_use_windows_threads();
-#else
-    evthread_use_pthreads();
-#endif
-
-    /* Create a new evhttp object to handle requests. */
-    raii_evhttp http_ctr = obtain_evhttp(base);
-    struct evhttp *http = http_ctr.get();
-    if (!http)
-    {
-        LogPrintf("couldn't create evhttp. Exiting.\n");
-        return;
-    }
-
-    evhttp_set_timeout(http, gArgs.GetArg("-rpcservertimeout", DEFAULT_HTTP_SERVER_TIMEOUT));
-    evhttp_set_max_headers_size(http, MAX_HEADERS_SIZE);
-    evhttp_set_max_body_size(http, MAX_SIZE);
-    evhttp_set_gencb(http, http_request_cb, (void*) this);
-
-    m_workQueue = new WorkQueue<HTTPClosure>(queueDepth);
-    LogPrintf("HTTP: creating work queue of depth %d\n", queueDepth);
-
-    // transfer ownership to eventBase/HTTP via .release()
-    m_eventHTTP = http_ctr.release(); 
-}
-
-HTTPSocket::~HTTPSocket()
-{
-    if (m_eventHTTP)
-    {
-        evhttp_free(m_eventHTTP);
-        m_eventHTTP = nullptr;
-    }
 }
 
 bool InitHTTPServer()
@@ -497,47 +442,6 @@ bool UpdateHTTPServerLogging(bool enable)
     // Can't update libevent logging if version < 02010100
     return false;
 #endif
-}
-
-std::thread threadHTTP;
-std::future<bool> threadResult;
-
-void HTTPSocket::StartHTTPSocket(int threadCount)
-{
-    for (int i = 0; i < threadCount; i++)
-    {
-        m_thread_http_workers.emplace_back(HTTPWorkQueueRun, m_workQueue);
-    }
-}
-
-void HTTPSocket::StopHTTPSocket()
-{
-    LogPrint(BCLog::HTTP, "Waiting for HTTP worker threads to exit\n");
-    for (auto &thread: m_thread_http_workers)
-    {
-        thread.join();
-    }
-    m_thread_http_workers.clear();
-
-    delete m_workQueue;
-    m_workQueue = nullptr;
-}
-
-void HTTPSocket::InterruptHTTPSocket()
-{
-    if (m_eventHTTP)
-    {
-        // Unlisten sockets
-        for (evhttp_bound_socket *socket : m_boundSockets)
-        {
-            evhttp_del_accept_socket(m_eventHTTP, socket);
-        }
-        // Reject requests on current connections
-        evhttp_set_gencb(m_eventHTTP, http_reject_request_cb, nullptr);
-    }
-
-    if (m_workQueue)
-        m_workQueue->Interrupt();
 }
 
 void StartHTTPServer()
@@ -617,6 +521,116 @@ void StopHTTPServer()
     LogPrint(BCLog::HTTP, "Stopped HTTP server\n");
 }
 
+struct event_base *EventBase()
+{
+    return eventBase;
+}
+
+static void httpevent_callback_fn(evutil_socket_t, short, void *data)
+{
+    // Static handler: simply call inner handler
+    HTTPEvent *self = static_cast<HTTPEvent *>(data);
+    self->handler();
+    if (self->deleteWhenTriggered)
+        delete self;
+}
+
+HTTPSocket::HTTPSocket(struct event_base *base, int timeout, int queueDepth)
+{
+#ifdef WIN32
+    evthread_use_windows_threads();
+#else
+    evthread_use_pthreads();
+#endif
+
+    /* Create a new evhttp object to handle requests. */
+    raii_evhttp http_ctr = obtain_evhttp(base);
+    struct evhttp *http = http_ctr.get();
+    if (!http)
+    {
+        LogPrintf("couldn't create evhttp. Exiting.\n");
+        return;
+    }
+
+    evhttp_set_timeout(http, gArgs.GetArg("-rpcservertimeout", DEFAULT_HTTP_SERVER_TIMEOUT));
+    evhttp_set_max_headers_size(http, MAX_HEADERS_SIZE);
+    evhttp_set_max_body_size(http, MAX_SIZE);
+    evhttp_set_gencb(http, http_request_cb, (void*) this);
+
+    m_workQueue = new WorkQueue<HTTPClosure>(queueDepth);
+    LogPrintf("HTTP: creating work queue of depth %d\n", queueDepth);
+
+    // transfer ownership to eventBase/HTTP via .release()
+    m_eventHTTP = http_ctr.release(); 
+}
+
+HTTPSocket::~HTTPSocket()
+{
+    if (m_eventHTTP)
+    {
+        evhttp_free(m_eventHTTP);
+        m_eventHTTP = nullptr;
+    }
+}
+
+void HTTPSocket::StartHTTPSocket(int threadCount)
+{
+    for (int i = 0; i < threadCount; i++)
+    {
+        m_thread_http_workers.emplace_back(HTTPWorkQueueRun, m_workQueue);
+    }
+}
+
+void HTTPSocket::StopHTTPSocket()
+{
+    LogPrint(BCLog::HTTP, "Waiting for HTTP worker threads to exit\n");
+    for (auto &thread: m_thread_http_workers)
+    {
+        thread.join();
+    }
+    m_thread_http_workers.clear();
+
+    delete m_workQueue;
+    m_workQueue = nullptr;
+}
+
+void HTTPSocket::InterruptHTTPSocket()
+{
+    if (m_eventHTTP)
+    {
+        // Unlisten sockets
+        for (evhttp_bound_socket *socket : m_boundSockets)
+        {
+            evhttp_del_accept_socket(m_eventHTTP, socket);
+        }
+        // Reject requests on current connections
+        evhttp_set_gencb(m_eventHTTP, http_reject_request_cb, nullptr);
+    }
+
+    if (m_workQueue)
+        m_workQueue->Interrupt();
+}
+
+void HTTPSocket::BindAddress(string ipAddr, int port)
+{ 
+    // Bind address
+    LogPrint(BCLog::HTTP, "Binding RPC on address %s port %i\n", ipAddr, port);
+    evhttp_bound_socket *bind_handle = evhttp_bind_socket_with_handle(m_eventHTTP,
+        ipAddr.empty() ? nullptr : ipAddr.c_str(), port);
+    if (bind_handle)
+    {
+        m_boundSockets.push_back(bind_handle);
+    } else
+    {
+        LogPrint(BCLog::HTTP,"Binding RPC on address %s port %i failed.\n", ipAddr, port);
+    }
+}
+
+int HTTPSocket::GetAddressCount()
+{
+    return m_boundSockets.size();
+}
+
 void HTTPSocket::RegisterHTTPHandler(const std::string &prefix, bool exactMatch, const HTTPRequestHandler &handler)
 {
     LogPrint(BCLog::HTTP, "Registering HTTP handler for %s (exactmatch %d)\n", prefix, exactMatch);
@@ -635,20 +649,6 @@ void HTTPSocket::UnregisterHTTPHandler(const std::string &prefix, bool exactMatc
         LogPrint(BCLog::HTTP, "Unregistering HTTP handler for %s (exactmatch %d)\n", prefix, exactMatch);
         m_pathHandlers.erase(i);
     }
-}
-
-struct event_base *EventBase()
-{
-    return eventBase;
-}
-
-static void httpevent_callback_fn(evutil_socket_t, short, void *data)
-{
-    // Static handler: simply call inner handler
-    HTTPEvent *self = static_cast<HTTPEvent *>(data);
-    self->handler();
-    if (self->deleteWhenTriggered)
-        delete self;
 }
 
 HTTPEvent::HTTPEvent(struct event_base *base, bool _deleteWhenTriggered, const std::function<void()> &_handler) :

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2018 The Pocketcoin Core developers
+// Copyright (c) 2015-2021 The Pocketcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,7 +9,6 @@
 #include <util.h>
 #include <utilstrencodings.h>
 #include <netbase.h>
-#include <rpc/protocol.h> // For HTTP status codes
 #include <sync.h>
 #include <ui_interface.h>
 
@@ -167,14 +166,10 @@ static struct event_base *eventBase = nullptr;
 struct evhttp *eventHTTP = nullptr;
 //! List of subnets to allow RPC connections from
 static std::vector<CSubNet> rpc_allow_subnets;
-//! Work queue for handling longer requests off the event loop thread
-static WorkQueue<HTTPClosure> *workQueue = nullptr;
-static WorkQueue<HTTPClosure> *workQueuePost = nullptr;
-static WorkQueue<HTTPClosure> *workQueuePublic = nullptr;
-//! Handlers for (sub)paths
-std::vector<HTTPPathHandler> pathHandlers;
-//! Bound listening sockets
-std::vector<evhttp_bound_socket *> boundSockets;
+//! HTTP socket objects to handle requests on different routes
+HTTPSocket *g_socket;
+HTTPSocket *g_pubSocket;
+HTTPSocket *g_postSocket;
 
 /** Check if a network address is allowed to access the HTTP server */
 static bool ClientAllowed(const CNetAddr &netaddr)
@@ -245,6 +240,7 @@ static std::string sendrawtransaction("sendrawtransaction");
 /** HTTP request callback */
 static void http_request_cb(struct evhttp_request *req, void *arg)
 {
+    HTTPSocket *httpSock = (HTTPSocket*) arg;
     // Disable reading to work around a libevent bug, fixed in 2.2.0.
     if (event_get_version_number() >= 0x02010600 && event_get_version_number() < 0x02020001)
     {
@@ -281,8 +277,8 @@ static void http_request_cb(struct evhttp_request *req, void *arg)
     // Find registered handler for prefix
     std::string strURI = hreq->GetURI();
     std::string path;
-    std::vector<HTTPPathHandler>::const_iterator i = pathHandlers.begin();
-    std::vector<HTTPPathHandler>::const_iterator iend = pathHandlers.end();
+    std::vector<HTTPPathHandler>::const_iterator i = httpSock->m_pathHandlers.begin();
+    std::vector<HTTPPathHandler>::const_iterator iend = httpSock->m_pathHandlers.end();
     for (; i != iend; ++i)
     {
         bool match = false;
@@ -302,40 +298,17 @@ static void http_request_cb(struct evhttp_request *req, void *arg)
     {
         std::unique_ptr<HTTPWorkItem> item(new HTTPWorkItem(std::move(hreq), path, i->handler));
 
-        if (strURI == "/post/")
+        assert(httpSock->m_workQueue);
+        if (httpSock->m_workQueue->Enqueue(item.get()))
+            item.release();
+        else
         {
-            assert(workQueuePost);
-            if (workQueuePost->Enqueue(item.get()))
-                item.release();
-            else
-            {
-                LogPrint(BCLog::RPC, "WARNING: request rejected because http work queue (POST) depth exceeded\n");
-                item->req->WriteReply(HTTP_INTERNAL, "Work queue depth exceeded (POST)");
-            }
-        } else if (strURI == "/public/")
-        {
-            assert(workQueuePublic);
-            if (workQueuePublic->Enqueue(item.get()))
-                item.release();
-            else
-            {
-                LogPrint(BCLog::RPC, "WARNING: request rejected because http work queue (PUBLIC) depth exceeded\n");
-                item->req->WriteReply(HTTP_INTERNAL, "Work queue depth exceeded (PUBLIC)");
-            }
-        } else
-        {
-            assert(workQueue);
-            if (workQueue->Enqueue(item.get()))
-                item.release();
-            else
-            {
-                LogPrint(BCLog::RPC, "WARNING: request rejected because http work queue (MAIN) depth exceeded.\n");
-                item->req->WriteReply(HTTP_INTERNAL, "Work queue depth exceeded (MAIN)");
-            }
+            LogPrint(BCLog::RPC, "WARNING: request rejected because http work queue depth exceeded.\n");
+            item->req->WriteReply(HTTP_INTERNAL, "Work queue depth exceeded");
         }
     } else
     {
-        LogPrint(BCLog::HTTP, "Rrequest from %s not found\n", hreq->GetPeer().ToString());
+        LogPrint(BCLog::HTTP, "Request from %s not found\n", hreq->GetPeer().ToString());
         hreq->WriteReply(HTTP_NOTFOUND);
     }
 }
@@ -358,17 +331,36 @@ static bool ThreadHTTP(struct event_base *base)
     return event_base_got_break(base) == 0;
 }
 
+void HTTPSocket::BindAddress(string ipAddr, int port)
+{ 
+    // Bind address
+    LogPrint(BCLog::HTTP, "Binding RPC on address %s port %i\n", ipAddr, port);
+    evhttp_bound_socket *bind_handle = evhttp_bind_socket_with_handle(m_eventHTTP,
+        ipAddr.empty() ? nullptr : ipAddr.c_str(), port);
+    if (bind_handle)
+    {
+        m_boundSockets.push_back(bind_handle);
+    } else
+    {
+        LogPrint(BCLog::HTTP,"Binding RPC on address %s port %i failed.\n", ipAddr, port);
+    }
+}
+
+int HTTPSocket::GetAddressCount()
+{
+    return m_boundSockets.size();
+}
+
 /** Bind HTTP server to specified addresses */
-static bool HTTPBindAddresses(struct evhttp *http)
+static bool HTTPBindAddresses()
 {
     int defaultPort = gArgs.GetArg("-rpcport", BaseParams().RPCPort());
-    std::vector<std::pair<std::string, uint16_t> > endpoints;
 
     // Determine what addresses to bind to
     if (!gArgs.IsArgSet("-rpcallowip"))
     { // Default to loopback if not allowing external IPs
-        endpoints.push_back(std::make_pair("::1", defaultPort));
-        endpoints.push_back(std::make_pair("127.0.0.1", defaultPort));
+        g_pubSocket->BindAddress("::1", defaultPort);
+        g_pubSocket->BindAddress("127.0.0.1", defaultPort);
         if (gArgs.IsArgSet("-rpcbind"))
         {
             LogPrintf(
@@ -381,29 +373,15 @@ static bool HTTPBindAddresses(struct evhttp *http)
             int port = defaultPort;
             std::string host;
             SplitHostPort(strRPCBind, port, host);
-            endpoints.push_back(std::make_pair(host, port));
+            g_pubSocket->BindAddress(host, port);
         }
     } else
     { // No specific bind address specified, bind to any
-        endpoints.push_back(std::make_pair("::", defaultPort));
-        endpoints.push_back(std::make_pair("0.0.0.0", defaultPort));
+        g_pubSocket->BindAddress("::", defaultPort);
+        g_pubSocket->BindAddress("0.0.0.0", defaultPort);
     }
 
-    // Bind addresses
-    for (std::vector<std::pair<std::string, uint16_t> >::iterator i = endpoints.begin(); i != endpoints.end(); ++i)
-    {
-        LogPrint(BCLog::HTTP, "Binding RPC on address %s port %i\n", i->first, i->second);
-        evhttp_bound_socket *bind_handle = evhttp_bind_socket_with_handle(http,
-            i->first.empty() ? nullptr : i->first.c_str(), i->second);
-        if (bind_handle)
-        {
-            boundSockets.push_back(bind_handle);
-        } else
-        {
-            LogPrintf("Binding RPC on address %s port %i failed.\n", i->first, i->second);
-        }
-    }
-    return !boundSockets.empty();
+    return (g_pubSocket->GetAddressCount());
 }
 
 /** Simple wrapper to set thread name and run work queue */
@@ -426,6 +404,44 @@ static void libevent_log_cb(int severity, const char *msg)
         LogPrint(BCLog::LIBEVENT, "libevent: %s\n", msg);
 }
 
+HTTPSocket::HTTPSocket(struct event_base *base, int timeout, int queueDepth)
+{
+#ifdef WIN32
+    evthread_use_windows_threads();
+#else
+    evthread_use_pthreads();
+#endif
+
+    /* Create a new evhttp object to handle requests. */
+    raii_evhttp http_ctr = obtain_evhttp(base);
+    struct evhttp *http = http_ctr.get();
+    if (!http)
+    {
+        LogPrintf("couldn't create evhttp. Exiting.\n");
+        return;
+    }
+
+    evhttp_set_timeout(http, gArgs.GetArg("-rpcservertimeout", DEFAULT_HTTP_SERVER_TIMEOUT));
+    evhttp_set_max_headers_size(http, MAX_HEADERS_SIZE);
+    evhttp_set_max_body_size(http, MAX_SIZE);
+    evhttp_set_gencb(http, http_request_cb, (void*) this);
+
+    m_workQueue = new WorkQueue<HTTPClosure>(queueDepth);
+    LogPrintf("HTTP: creating work queue of depth %d\n", queueDepth);
+
+    // transfer ownership to eventBase/HTTP via .release()
+    m_eventHTTP = http_ctr.release(); 
+}
+
+HTTPSocket::~HTTPSocket()
+{
+    if (m_eventHTTP)
+    {
+        evhttp_free(m_eventHTTP);
+        m_eventHTTP = nullptr;
+    }
+}
+
 bool InitHTTPServer()
 {
     if (!InitHTTPAllowList())
@@ -440,52 +456,29 @@ bool InitHTTPServer()
     {
         g_logger->DisableCategory(BCLog::LIBEVENT);
     }
-
-#ifdef WIN32
-    evthread_use_windows_threads();
-#else
-    evthread_use_pthreads();
-#endif
+    
+    int timeout = gArgs.GetArg("-rpcservertimeout", DEFAULT_HTTP_SERVER_TIMEOUT);
+    int workQueueMainDepth = std::max((long) gArgs.GetArg("-rpcworkqueue", DEFAULT_HTTP_WORKQUEUE), 1L);
+    int workQueuePostDepth = std::max((long) gArgs.GetArg("-rpcpostworkqueue", DEFAULT_HTTP_POST_WORKQUEUE), 1L);
+    int workQueuePublicDepth = std::max((long) gArgs.GetArg("-rpcpublicworkqueue", DEFAULT_HTTP_PUBLIC_WORKQUEUE), 1L);
 
     raii_event_base base_ctr = obtain_event_base();
+    eventBase = base_ctr.get();
 
-    /* Create a new evhttp object to handle requests. */
-    raii_evhttp http_ctr = obtain_evhttp(base_ctr.get());
-    struct evhttp *http = http_ctr.get();
-    if (!http)
-    {
-        LogPrintf("couldn't create evhttp. Exiting.\n");
-        return false;
-    }
-
-    evhttp_set_timeout(http, gArgs.GetArg("-rpcservertimeout", DEFAULT_HTTP_SERVER_TIMEOUT));
-    evhttp_set_max_headers_size(http, MAX_HEADERS_SIZE);
-    evhttp_set_max_body_size(http, MAX_SIZE);
-    evhttp_set_gencb(http, http_request_cb, nullptr);
-
-    if (!HTTPBindAddresses(http))
+    g_socket = new HTTPSocket(eventBase, timeout, workQueueMainDepth);
+    g_pubSocket = new HTTPSocket(eventBase, timeout, workQueuePublicDepth);
+    g_postSocket = new HTTPSocket(eventBase, timeout, workQueuePostDepth);
+ 
+    if (!HTTPBindAddresses())
     {
         LogPrintf("Unable to bind any endpoint for RPC server\n");
         return false;
     }
 
     LogPrint(BCLog::HTTP, "Initialized HTTP server\n");
-    int workQueueMainDepth = std::max((long) gArgs.GetArg("-rpcworkqueue", DEFAULT_HTTP_WORKQUEUE), 1L);
-    int workQueuePostDepth = std::max((long) gArgs.GetArg("-rpcpostworkqueue", DEFAULT_HTTP_POST_WORKQUEUE), 1L);
-    int workQueuePublicDepth = std::max((long) gArgs.GetArg("-rpcpublicworkqueue", DEFAULT_HTTP_PUBLIC_WORKQUEUE), 1L);
-
-    workQueue = new WorkQueue<HTTPClosure>(workQueueMainDepth);
-    LogPrintf("HTTP: creating work queue of depth %d\n", workQueueMainDepth);
-
-    workQueuePost = new WorkQueue<HTTPClosure>(workQueuePostDepth);
-    LogPrintf("HTTP: creating work queue of depth %d\n", workQueuePostDepth);
-
-    workQueuePublic = new WorkQueue<HTTPClosure>(workQueuePublicDepth);
-    LogPrintf("HTTP: creating work queue of depth %d\n", workQueuePublicDepth);
 
     // transfer ownership to eventBase/HTTP via .release()
     eventBase = base_ctr.release();
-    eventHTTP = http_ctr.release();
     return true;
 }
 
@@ -508,7 +501,44 @@ bool UpdateHTTPServerLogging(bool enable)
 
 std::thread threadHTTP;
 std::future<bool> threadResult;
-static std::vector<std::thread> g_thread_http_workers;
+
+void HTTPSocket::StartHTTPSocket(int threadCount)
+{
+    for (int i = 0; i < threadCount; i++)
+    {
+        m_thread_http_workers.emplace_back(HTTPWorkQueueRun, m_workQueue);
+    }
+}
+
+void HTTPSocket::StopHTTPSocket()
+{
+    LogPrint(BCLog::HTTP, "Waiting for HTTP worker threads to exit\n");
+    for (auto &thread: m_thread_http_workers)
+    {
+        thread.join();
+    }
+    m_thread_http_workers.clear();
+
+    delete m_workQueue;
+    m_workQueue = nullptr;
+}
+
+void HTTPSocket::InterruptHTTPSocket()
+{
+    if (m_eventHTTP)
+    {
+        // Unlisten sockets
+        for (evhttp_bound_socket *socket : m_boundSockets)
+        {
+            evhttp_del_accept_socket(m_eventHTTP, socket);
+        }
+        // Reject requests on current connections
+        evhttp_set_gencb(m_eventHTTP, http_reject_request_cb, nullptr);
+    }
+
+    if (m_workQueue)
+        m_workQueue->Interrupt();
+}
 
 void StartHTTPServer()
 {
@@ -521,46 +551,22 @@ void StartHTTPServer()
     threadResult = task.get_future();
     threadHTTP = std::thread(std::move(task), eventBase);
 
-    for (int i = 0; i < rpcMainThreads; i++)
-    {
-        g_thread_http_workers.emplace_back(HTTPWorkQueueRun, workQueue);
-    }
     LogPrintf("HTTP: starting %d Main worker threads\n", rpcMainThreads);
+    g_socket->StartHTTPSocket(rpcMainThreads);
 
-    for (int i = 0; i < rpcPostThreads; i++)
-    {
-        g_thread_http_workers.emplace_back(HTTPWorkQueueRun, workQueuePost);
-    }
     LogPrintf("HTTP: starting %d Post worker threads\n", rpcPostThreads);
+    g_postSocket->StartHTTPSocket(rpcPostThreads);
 
-    for (int i = 0; i < rpcPublicThreads; i++)
-    {
-        g_thread_http_workers.emplace_back(HTTPWorkQueueRun, workQueuePublic);
-    }
     LogPrintf("HTTP: starting %d Public worker threads\n", rpcPublicThreads);
+    g_pubSocket->StartHTTPSocket(rpcPublicThreads);
 }
 
 void InterruptHTTPServer()
 {
     LogPrint(BCLog::HTTP, "Interrupting HTTP server\n");
-    if (eventHTTP)
-    {
-        // Unlisten sockets
-        for (evhttp_bound_socket *socket : boundSockets)
-        {
-            evhttp_del_accept_socket(eventHTTP, socket);
-        }
-        // Reject requests on current connections
-        evhttp_set_gencb(eventHTTP, http_reject_request_cb, nullptr);
-    }
-    if (workQueue)
-        workQueue->Interrupt();
-
-    if (workQueuePost)
-        workQueuePost->Interrupt();
-
-    if (workQueuePublic)
-        workQueuePublic->Interrupt();
+    g_socket->InterruptHTTPSocket();
+    g_pubSocket->InterruptHTTPSocket();
+    g_postSocket->InterruptHTTPSocket();
 }
 
 void StopHTTPServer()
@@ -568,35 +574,16 @@ void StopHTTPServer()
     LogPrint(BCLog::HTTP, "Stopping HTTP server\n");
 
     LogPrint(BCLog::HTTP, "Waiting for HTTP worker threads to exit\n");
-    for (auto &thread: g_thread_http_workers)
-    {
-        thread.join();
-    }
-    g_thread_http_workers.clear();
-
-    if (workQueue)
-    {
-        delete workQueue;
-        workQueue = nullptr;
-    }
-
-    if (workQueuePost)
-    {
-        delete workQueuePost;
-        workQueuePost = nullptr;
-    }
-
-    if (workQueuePublic)
-    {
-        delete workQueuePublic;
-        workQueuePublic = nullptr;
-    }
+    g_socket->StopHTTPSocket();
+    g_pubSocket->StopHTTPSocket();
+    g_postSocket->StopHTTPSocket();
 
     if (eventBase)
     {
         LogPrint(BCLog::HTTP, "Waiting for HTTP event thread to exit\n");
         // Exit the event loop as soon as there are no active events.
         event_base_loopexit(eventBase, nullptr);
+
         // Give event loop a few seconds to exit (to send back last RPC responses), then break it
         // Before this was solved with event_base_loopexit, but that didn't work as expected in
         // at least libevent 2.0.21 and always introduced a delay. In libevent
@@ -609,13 +596,18 @@ void StopHTTPServer()
             LogPrintf("HTTP event loop did not exit within allotted time, sending loopbreak\n");
             event_base_loopbreak(eventBase);
         }
+
         threadHTTP.join();
     }
-    if (eventHTTP)
-    {
-        evhttp_free(eventHTTP);
-        eventHTTP = nullptr;
-    }
+
+    delete g_socket;
+    g_socket = nullptr;
+
+    delete g_pubSocket;
+    g_pubSocket = nullptr;
+
+    delete g_postSocket;
+    g_postSocket = nullptr;
 
     if (eventBase)
     {
@@ -623,6 +615,26 @@ void StopHTTPServer()
         eventBase = nullptr;
     }
     LogPrint(BCLog::HTTP, "Stopped HTTP server\n");
+}
+
+void HTTPSocket::RegisterHTTPHandler(const std::string &prefix, bool exactMatch, const HTTPRequestHandler &handler)
+{
+    LogPrint(BCLog::HTTP, "Registering HTTP handler for %s (exactmatch %d)\n", prefix, exactMatch);
+    m_pathHandlers.push_back(HTTPPathHandler(prefix, exactMatch, handler));
+}
+
+void HTTPSocket::UnregisterHTTPHandler(const std::string &prefix, bool exactMatch)
+{
+    std::vector<HTTPPathHandler>::iterator i = m_pathHandlers.begin();
+    std::vector<HTTPPathHandler>::iterator iend = m_pathHandlers.end();
+    for (; i != iend; ++i)
+        if (i->prefix == prefix && i->exactMatch == exactMatch)
+            break;
+    if (i != iend)
+    {
+        LogPrint(BCLog::HTTP, "Unregistering HTTP handler for %s (exactmatch %d)\n", prefix, exactMatch);
+        m_pathHandlers.erase(i);
+    }
 }
 
 struct event_base *EventBase()
@@ -784,26 +796,6 @@ HTTPRequest::RequestMethod HTTPRequest::GetRequestMethod() const
         default:
             return UNKNOWN;
             break;
-    }
-}
-
-void RegisterHTTPHandler(const std::string &prefix, bool exactMatch, const HTTPRequestHandler &handler)
-{
-    LogPrint(BCLog::HTTP, "Registering HTTP handler for %s (exactmatch %d)\n", prefix, exactMatch);
-    pathHandlers.push_back(HTTPPathHandler(prefix, exactMatch, handler));
-}
-
-void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch)
-{
-    std::vector<HTTPPathHandler>::iterator i = pathHandlers.begin();
-    std::vector<HTTPPathHandler>::iterator iend = pathHandlers.end();
-    for (; i != iend; ++i)
-        if (i->prefix == prefix && i->exactMatch == exactMatch)
-            break;
-    if (i != iend)
-    {
-        LogPrint(BCLog::HTTP, "Unregistering HTTP handler for %s (exactmatch %d)\n", prefix, exactMatch);
-        pathHandlers.erase(i);
     }
 }
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -169,7 +169,6 @@ static std::vector<CSubNet> rpc_allow_subnets;
 //! HTTP socket objects to handle requests on different routes
 HTTPSocket *g_socket;
 HTTPSocket *g_pubSocket;
-HTTPSocket *g_postSocket;
 
 std::thread threadHTTP;
 std::future<bool> threadResult;
@@ -337,13 +336,16 @@ static bool ThreadHTTP(struct event_base *base)
 /** Bind HTTP server to specified addresses */
 static bool HTTPBindAddresses()
 {
-    int defaultPort = gArgs.GetArg("-rpcport", BaseParams().RPCPort());
+    int publicPort = gArgs.GetArg("-publicrpcport", BaseParams().PublicRPCPort());
+    int securePort = gArgs.GetArg("-rpcport", BaseParams().RPCPort());
 
     // Determine what addresses to bind to
     if (!gArgs.IsArgSet("-rpcallowip"))
     { // Default to loopback if not allowing external IPs
-        g_pubSocket->BindAddress("::1", defaultPort);
-        g_pubSocket->BindAddress("127.0.0.1", defaultPort);
+        g_pubSocket->BindAddress("::1", pubicPort);
+        g_pubSocket->BindAddress("127.0.0.1", pubicPort);
+        g_socket->BindAddress("::1", securePort);
+        g_socket->BindAddress("127.0.0.1", securePort);
         if (gArgs.IsArgSet("-rpcbind"))
         {
             LogPrintf(
@@ -353,15 +355,17 @@ static bool HTTPBindAddresses()
     { // Specific bind address
         for (const std::string &strRPCBind : gArgs.GetArgs("-rpcbind"))
         {
-            int port = defaultPort;
             std::string host;
-            SplitHostPort(strRPCBind, port, host);
-            g_pubSocket->BindAddress(host, port);
+            SplitHostPort(strRPCBind, pubicPort, host);
+            g_pubSocket->BindAddress(host, pubicPort);
+            g_socket->BindAddress(host, securePort);
         }
     } else
     { // No specific bind address specified, bind to any
-        g_pubSocket->BindAddress("::", defaultPort);
-        g_pubSocket->BindAddress("0.0.0.0", defaultPort);
+        g_pubSocket->BindAddress("::", pubicPort);
+        g_pubSocket->BindAddress("0.0.0.0", pubicPort);
+        g_socket->BindAddress("::", securePort);
+        g_socket->BindAddress("0.0.0.0", securePort);
     }
 
     return (g_pubSocket->GetAddressCount());
@@ -401,6 +405,12 @@ bool InitHTTPServer()
     {
         g_logger->DisableCategory(BCLog::LIBEVENT);
     }
+
+#ifdef WIN32
+    evthread_use_windows_threads();
+#else
+    evthread_use_pthreads();
+#endif
     
     int timeout = gArgs.GetArg("-rpcservertimeout", DEFAULT_HTTP_SERVER_TIMEOUT);
     int workQueueMainDepth = std::max((long) gArgs.GetArg("-rpcworkqueue", DEFAULT_HTTP_WORKQUEUE), 1L);
@@ -412,7 +422,6 @@ bool InitHTTPServer()
 
     g_socket = new HTTPSocket(eventBase, timeout, workQueueMainDepth);
     g_pubSocket = new HTTPSocket(eventBase, timeout, workQueuePublicDepth);
-    g_postSocket = new HTTPSocket(eventBase, timeout, workQueuePostDepth);
  
     if (!HTTPBindAddresses())
     {
@@ -458,11 +467,10 @@ void StartHTTPServer()
     LogPrintf("HTTP: starting %d Main worker threads\n", rpcMainThreads);
     g_socket->StartHTTPSocket(rpcMainThreads);
 
-    LogPrintf("HTTP: starting %d Post worker threads\n", rpcPostThreads);
-    g_postSocket->StartHTTPSocket(rpcPostThreads);
-
-    LogPrintf("HTTP: starting %d Public worker threads\n", rpcPublicThreads);
-    g_pubSocket->StartHTTPSocket(rpcPublicThreads);
+    // The same worker threads will service POST and PUBLIC RPC requests
+    int pubThreads = rpcPostThreads + rpcPublicThreads;
+    LogPrintf("HTTP: starting %d Public worker threads\n", pubThreads);
+    g_pubSocket->StartHTTPSocket(pubThreads);
 }
 
 void InterruptHTTPServer()
@@ -470,7 +478,6 @@ void InterruptHTTPServer()
     LogPrint(BCLog::HTTP, "Interrupting HTTP server\n");
     g_socket->InterruptHTTPSocket();
     g_pubSocket->InterruptHTTPSocket();
-    g_postSocket->InterruptHTTPSocket();
 }
 
 void StopHTTPServer()
@@ -480,7 +487,6 @@ void StopHTTPServer()
     LogPrint(BCLog::HTTP, "Waiting for HTTP worker threads to exit\n");
     g_socket->StopHTTPSocket();
     g_pubSocket->StopHTTPSocket();
-    g_postSocket->StopHTTPSocket();
 
     if (eventBase)
     {
@@ -510,9 +516,6 @@ void StopHTTPServer()
     delete g_pubSocket;
     g_pubSocket = nullptr;
 
-    delete g_postSocket;
-    g_postSocket = nullptr;
-
     if (eventBase)
     {
         event_base_free(eventBase);
@@ -535,14 +538,10 @@ static void httpevent_callback_fn(evutil_socket_t, short, void *data)
         delete self;
 }
 
-HTTPSocket::HTTPSocket(struct event_base *base, int timeout, int queueDepth)
+HTTPSocket::HTTPSocket(struct event_base *base, int timeout, int queueDepth): m_http(nullptr),
+                                                                              m_eventHTTP(nullptr),
+                                                                              m_workQueue(nullptr)
 {
-#ifdef WIN32
-    evthread_use_windows_threads();
-#else
-    evthread_use_pthreads();
-#endif
-
     /* Create a new evhttp object to handle requests. */
     raii_evhttp http_ctr = obtain_evhttp(base);
     struct evhttp *http = http_ctr.get();
@@ -729,6 +728,7 @@ void HTTPRequest::WriteHeader(const std::string &hdr, const std::string &value)
 void HTTPRequest::WriteReply(int nStatus, const std::string &strReply)
 {
     assert(!replySent && req);
+
     // Send event to main http thread to send reply message
     struct evbuffer *evb = evhttp_request_get_output_buffer(req);
     assert(evb);

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -27,7 +27,6 @@ static const int DEFAULT_HTTP_PUBLIC_WORKQUEUE=16;
 static const int DEFAULT_HTTP_SERVER_TIMEOUT=30;
 
 struct evhttp_request;
-//struct event_base;
 class CService;
 class HTTPRequest;
 template<typename WorkItem> class WorkQueue;
@@ -143,7 +142,7 @@ public:
      * deleteWhenTriggered deletes this event object after the event is triggered (and the handler called)
      * handler is the handler to call when the event is triggered.
      */
-    HTTPEvent(struct event_base *base, bool deleteWhenTriggered, const std::function<void()>& handler);
+    HTTPEvent(struct event_base* base, bool deleteWhenTriggered, const std::function<void()>& handler);
     ~HTTPEvent();
 
     /** Trigger the event. If tv is 0, trigger it immediately. Otherwise trigger it after

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -163,7 +163,7 @@ private:
     struct evhttp                      *m_http;
     struct evhttp                      *m_eventHTTP;
     std::vector<evhttp_bound_socket *> m_boundSockets;
-    std::vector<std::thread>           m_thread_http_workers;    
+    std::vector<std::thread>           m_thread_http_workers; 
 
 public:
     HTTPSocket(struct event_base *base, int timeout, int queueDepth);
@@ -173,9 +173,13 @@ public:
     WorkQueue<HTTPClosure> *m_workQueue;
     std::vector<HTTPPathHandler> m_pathHandlers;
 
+    /** Start worker threads to listen on bound http sockets */
     void StartHTTPSocket(int threadCount);
+    /** Stop worker threads on all bound http sockets */
     void StopHTTPSocket();
+    /** Acquire a http socket handle for a provided IP address and port number */
     void BindAddress(std::string ipAddr, int port);
+    /** Get number of bound IP sockets */
     int  GetAddressCount();
 
     void InterruptHTTPSocket();
@@ -192,6 +196,5 @@ std::string urlDecode(const std::string &urlEncoded);
 
 extern HTTPSocket *g_socket;
 extern HTTPSocket *g_pubSocket;
-extern HTTPSocket *g_postSocket;
 
 #endif // POCKETCOIN_HTTPSERVER_H

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -8,6 +8,15 @@
 #include <string>
 #include <stdint.h>
 #include <functional>
+#include <future>
+#include <rpc/protocol.h> // For HTTP status codes
+#include <event2/thread.h>
+#include <event2/buffer.h>
+#include <event2/bufferevent.h>
+#include <event2/util.h>
+#include <event2/keyvalq_struct.h>
+
+#include <support/events.h>
 
 static const int DEFAULT_HTTP_THREADS=4;
 static const int DEFAULT_HTTP_POST_THREADS=4;
@@ -18,9 +27,12 @@ static const int DEFAULT_HTTP_PUBLIC_WORKQUEUE=16;
 static const int DEFAULT_HTTP_SERVER_TIMEOUT=30;
 
 struct evhttp_request;
-struct event_base;
+//struct event_base;
 class CService;
 class HTTPRequest;
+template<typename WorkItem> class WorkQueue;
+
+struct HTTPPathHandler;
 
 /** Initialize HTTP server.
  * Call this before RegisterHTTPHandler or EventBase().
@@ -42,13 +54,6 @@ bool UpdateHTTPServerLogging(bool enable);
 
 /** Handler for requests to a certain HTTP path */
 typedef std::function<bool(HTTPRequest* req, const std::string &)> HTTPRequestHandler;
-/** Register handler for prefix.
- * If multiple handlers match a prefix, the first-registered one will
- * be invoked.
- */
-void RegisterHTTPHandler(const std::string &prefix, bool exactMatch, const HTTPRequestHandler &handler);
-/** Unregister handler for prefix */
-void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch);
 
 /** Return evhttp event base. This can be used by submodules to
  * queue timers or custom events.
@@ -138,7 +143,7 @@ public:
      * deleteWhenTriggered deletes this event object after the event is triggered (and the handler called)
      * handler is the handler to call when the event is triggered.
      */
-    HTTPEvent(struct event_base* base, bool deleteWhenTriggered, const std::function<void()>& handler);
+    HTTPEvent(struct event_base *base, bool deleteWhenTriggered, const std::function<void()>& handler);
     ~HTTPEvent();
 
     /** Trigger the event. If tv is 0, trigger it immediately. Otherwise trigger it after
@@ -152,6 +157,41 @@ private:
     struct event* ev;
 };
 
+class HTTPSocket
+{
+private:
+    struct evhttp                      *m_http;
+    struct evhttp                      *m_eventHTTP;
+    std::vector<evhttp_bound_socket *> m_boundSockets;
+    std::vector<std::thread>           m_thread_http_workers;    
+
+public:
+    HTTPSocket(struct event_base *base, int timeout, int queueDepth);
+    ~HTTPSocket();
+
+    /** Work queue for handling longer requests off the event loop thread */
+    WorkQueue<HTTPClosure> *m_workQueue;
+    std::vector<HTTPPathHandler> m_pathHandlers;
+
+    void StartHTTPSocket(int threadCount);
+    void StopHTTPSocket();
+    void BindAddress(std::string ipAddr, int port);
+    int  GetAddressCount();
+
+    void InterruptHTTPSocket();
+    /** Register handler for prefix.
+     * If multiple handlers match a prefix, the first-registered one will
+     * be invoked.
+     */
+    void RegisterHTTPHandler(const std::string &prefix, bool exactMatch, const HTTPRequestHandler &handler);
+    /** Unregister handler for prefix */
+    void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch);
+};
+
 std::string urlDecode(const std::string &urlEncoded);
+
+extern HTTPSocket *g_socket;
+extern HTTPSocket *g_pubSocket;
+extern HTTPSocket *g_postSocket;
 
 #endif // POCKETCOIN_HTTPSERVER_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -766,13 +766,21 @@ static bool InitSanityCheck()
 
 static bool AppInitServers()
 {
+    
     RPCServer::OnStarted(&OnRPCStarted);
     RPCServer::OnStopped(&OnRPCStopped);
     if (!InitHTTPServer())
+    {
         return false;
+    }
+
     StartRPC();
+
     if (!StartHTTPRPC())
+    {
         return false;
+    }
+
     if (gArgs.GetBoolArg("-rest", DEFAULT_REST_ENABLE)) StartREST();
     StartHTTPServer();
     return true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -515,7 +515,8 @@ void SetupServerArgs()
     gArgs.AddArg("-rpcbind=<addr>[:port]", "Bind to given address to listen for JSON-RPC connections. This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -rpcport. Use [host]:port notation for IPv6. This option can be specified multiple times (default: 127.0.0.1 and ::1 i.e., localhost, or if -rpcallowip has been specified, 0.0.0.0 and :: i.e., all addresses)", false, OptionsCategory::RPC);
     gArgs.AddArg("-rpccookiefile=<loc>", "Location of the auth cookie. Relative paths will be prefixed by a net-specific datadir location. (default: data dir)", false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcpassword=<pw>", "Password for JSON-RPC connections", false, OptionsCategory::RPC);
-    gArgs.AddArg("-rpcport=<port>", strprintf("Listen for JSON-RPC connections on <port> (default: %u, testnet: %u, regtest: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort(), regtestBaseParams->RPCPort()), false, OptionsCategory::RPC);
+    gArgs.AddArg("-rpcport=<port>", strprintf("Listen for secure JSON-RPC connections on <port> (default: %u, testnet: %u, regtest: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort(), regtestBaseParams->RPCPort()), false, OptionsCategory::RPC);
+    gArgs.AddArg("-publicrpcport=<port>", strprintf("Listen for public JSON-RPC connections on <port> (default: %u, testnet: %u, regtest: %u)", defaultBaseParams->PublicRPCPort(), testnetBaseParams->PublicRPCPort(), regtestBaseParams->PublicRPCPort()), false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcserialversion", strprintf("Sets the serialization of raw transaction or block hex returned in non-verbose mode, non-segwit(0) or segwit(1) (default: %d)", DEFAULT_RPC_SERIALIZE_VERSION), false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT), true, OptionsCategory::RPC);
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -594,7 +594,7 @@ static const struct {
 void StartREST()
 {
     for (unsigned int i = 0; i < ARRAYLEN(uri_prefixes); i++)
-        RegisterHTTPHandler(uri_prefixes[i].prefix, false, uri_prefixes[i].handler);
+        g_socket->RegisterHTTPHandler(uri_prefixes[i].prefix, false, uri_prefixes[i].handler);
 }
 
 void InterruptREST()
@@ -604,5 +604,5 @@ void InterruptREST()
 void StopREST()
 {
     for (unsigned int i = 0; i < ARRAYLEN(uri_prefixes); i++)
-        UnregisterHTTPHandler(uri_prefixes[i].prefix, false);
+        g_socket->UnregisterHTTPHandler(uri_prefixes[i].prefix, false);
 }


### PR DESCRIPTION
Create new HTTPSocket class to handle multiple HTTP RPC socket connections using different paths.  Tested by connecting to testnet and performing both authenticated and public RPC requests using CURL.
Add new -publicrpcport parameter to specify socket port number for public RPC requests.