### PR TITLE
Cache mechanism for RPC requests in new RPCCache class

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -515,6 +515,7 @@ POCKETCOIN_CORE_H = \
     reverse_iterator.h \
     reverselock.h \
     rpc/blockchain.h \
+    rpc/cache.h \
     rpc/client.h \
     rpc/mining.h \
     rpc/protocol.h \
@@ -622,6 +623,7 @@ libpocketcoin_server_a_SOURCES = \
     pow.cpp \
     rest.cpp \
     rpc/blockchain.cpp \
+    rpc/cache.cpp \
     rpc/mining.cpp \
     rpc/misc.cpp \
     rpc/net.cpp \

--- a/src/rpc/cache.cpp
+++ b/src/rpc/cache.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 The Pocketcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <rpc/cache.h>
+#include <rpc/server.h>
+
+std::string RPCCache::MakeHashKey(const JSONRPCRequest& req)
+{
+    std::string hashKey = req.strMethod;
+
+    hashKey += req.params.write();
+
+    return hashKey;
+}
+
+void RPCCache::Clear()
+{
+    LOCK(CacheMutex);
+    m_cache.clear();
+    m_blockHeight = chainActive.Height();
+
+    LogPrint(BCLog::RPC, "RPC cache cleared.\n");
+}
+
+void RPCCache::Put(const std::string& path, const UniValue& content)
+{
+    if (chainActive.Height() > m_blockHeight)
+        this->Clear();
+
+    LOCK(CacheMutex);
+    if (m_cache.find(path) == m_cache.end()) {
+        LogPrint(BCLog::RPC, "RPC cache put '%s'\n", path);
+        m_cache.emplace(path, content);
+    } else {
+        LogPrint(BCLog::RPC, "RPC cache put update '%s'\n", path);
+        m_cache[path] = content;
+    }
+}
+
+UniValue RPCCache::Get(const std::string& path)
+{
+    if (m_cache.empty()) {
+        return UniValue();
+    }
+
+    if (chainActive.Height() > m_blockHeight) {
+        this->Clear();
+        return UniValue();
+    }
+
+    LOCK(CacheMutex);
+    if (m_cache.find(path) != m_cache.end()) {
+        LogPrint(BCLog::RPC, "RPC Cache get found %s in cache\n", path);
+        return m_cache.at(path);
+    }
+
+    /* Return empty UniValue if nothing found in cache. */
+    return UniValue();
+}
+
+UniValue RPCCache::GetRpcCache(const JSONRPCRequest& req)
+{
+    // Return empty UniValue if method not supported for caching.
+    if (std::find(supportedMethods.begin(), supportedMethods.end(), req.strMethod) == supportedMethods.end())
+        return UniValue();
+
+    return Get(MakeHashKey(req));
+}
+
+void RPCCache::PutRpcCache(const JSONRPCRequest& req, const UniValue& content)
+{
+    if (std::find(supportedMethods.begin(), supportedMethods.end(), req.strMethod) == supportedMethods.end())
+        return;
+
+    Put(MakeHashKey(req), content);
+}

--- a/src/rpc/cache.h
+++ b/src/rpc/cache.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 The Pocketcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef POCKETCOIN_RPC_CACHE_H
+#define POCKETCOIN_RPC_CACHE_H
+#include <univalue.h>
+#include <sync.h>
+#include <logging.h>
+#include <validation.h>
+
+class JSONRPCRequest;
+
+class RPCCache
+{
+private:
+    Mutex CacheMutex;
+    std::map<std::string, UniValue> m_cache;
+    int m_blockHeight;
+    const std::vector<std::string> supportedMethods = {"getlastcomments",
+                                                       "getcomments",
+                                                       "gettags",
+                                                       "getnodeinfo",
+                                                       "getrawtransactionwithmessagebyid",
+                                                       "getrawtransactionwithmessage",
+                                                       "getrawtransaction",
+                                                       "getusercontents",
+                                                       "gethierarchicalstrip",
+                                                       "gethotposts",
+                                                       "getuserprofile",
+                                                       "getuserstate",
+                                                       "getpagescores",
+                                                       "getcontents",
+                                                       "gethistoricalstrip",
+                                                       "gethierarchicalstrip",
+                                                       "getcontentsstatistic"};
+
+    /* Make a key for the unordered hash map by concatenating together the methodname and
+     * params.  TODO: We will likely need to improve this methodology in the future in
+     * case parameters are delivered in out of order by the front-end clients.
+     */
+    std::string MakeHashKey(const JSONRPCRequest& req);
+
+public:
+    RPCCache() 
+    {
+        m_blockHeight = chainActive.Height();
+    }
+
+    void Clear();
+
+    void Put(const std::string& path, const UniValue& content);
+
+    UniValue Get(const std::string& path);
+
+    UniValue GetRpcCache(const JSONRPCRequest& req);
+
+    void PutRpcCache(const JSONRPCRequest& req, const UniValue& content);
+
+};
+
+#endif // POCKETCOIN_RPC_CACHE_H

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -272,6 +272,7 @@ static const CRPCCommand vRPCCommands[] =
 CRPCTable::CRPCTable()
 {
     unsigned int vcidx;
+    cache = new RPCCache();
     for (vcidx = 0; vcidx < (sizeof(vRPCCommands) / sizeof(vRPCCommands[0])); vcidx++)
     {
         const CRPCCommand *pcmd;
@@ -476,7 +477,7 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
     return out;
 }
 
-UniValue CRPCTable::execute(const JSONRPCRequest &request) const
+UniValue CRPCTable::execute(const JSONRPCRequest &request)
 {
     // Return immediately if in warmup
     {
@@ -491,19 +492,28 @@ UniValue CRPCTable::execute(const JSONRPCRequest &request) const
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found");
 
     g_rpcSignals.PreCommand(*pcmd);
-    try
-    {
-        // Execute, convert arguments to array if necessary
-        if (request.params.isObject()) {
-            return pcmd->actor(transformNamedArguments(request, pcmd->argNames));
-        } else {
-            return pcmd->actor(request);
+
+    // See if this request reply is cached 
+    UniValue ret = cache->GetRpcCache(request);
+    if (ret.isNull()) {
+        try
+        {
+            // Execute, convert arguments to array if necessary
+            if (request.params.isObject()) {
+                ret = pcmd->actor(transformNamedArguments(request, pcmd->argNames));
+            } else {
+                ret = pcmd->actor(request);
+            }
+            // Save return value in cache for later
+            cache->PutRpcCache(request, ret);
+        }
+        catch (const std::exception& e)
+        {
+            throw JSONRPCError(RPC_MISC_ERROR, e.what());
         }
     }
-    catch (const std::exception& e)
-    {
-        throw JSONRPCError(RPC_MISC_ERROR, e.what());
-    }
+
+    return ret;
 }
 
 std::vector<std::string> CRPCTable::listCommands() const

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -8,6 +8,7 @@
 
 #include <amount.h>
 #include <rpc/protocol.h>
+#include <rpc/cache.h>
 #include <uint256.h>
 
 #include <list>
@@ -145,6 +146,7 @@ class CRPCTable
 {
 private:
     std::map<std::string, const CRPCCommand*> mapCommands;
+    RPCCache *cache;
 public:
     CRPCTable();
     const CRPCCommand* operator[](const std::string& name) const;
@@ -156,7 +158,7 @@ public:
      * @returns Result of the call.
      * @throws an exception (UniValue) when an error happens.
      */
-    UniValue execute(const JSONRPCRequest &request) const;
+    UniValue execute(const JSONRPCRequest &request);
 
     /**
     * Returns a list of registered commands


### PR DESCRIPTION
 - RPC cache stores reply message for a given RPC method and arguments.

 - Cache is reset every block, approx every minute.

 - 16 RPC methods are supported for caching