### PR TITLE
Feature/rpccache: Set 64MB default limit to RPC cache with command line parameter config

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -529,6 +529,7 @@ void SetupServerArgs()
     gArgs.AddArg("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcworkpostqueue=<n>", strprintf("Set the depth of the work queue to service RPC (POST) calls (default: %d)", DEFAULT_HTTP_POST_WORKQUEUE), false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcworkpublicqueue=<n>", strprintf("Set the depth of the work queue to service RPC (PUBLIC) calls (default: %d)", DEFAULT_HTTP_PUBLIC_WORKQUEUE), false, OptionsCategory::RPC);
+    gArgs.AddArg("-rpccachesize=<n>", strprintf("Maximum amount of memory in megabytes allowed for RPCcache usage (default: %d MB)", 64), false, OptionsCategory::RPC);
 
     gArgs.AddArg("-statdepth=<n>", strprintf("Set the depth of the work queue for statistic in seconds (default: %ds)", 60), false, OptionsCategory::RPC);
 

--- a/src/rpc/cache.cpp
+++ b/src/rpc/cache.cpp
@@ -5,6 +5,14 @@
 #include <rpc/cache.h>
 #include <rpc/server.h>
 
+static const unsigned int MAX_CACHE_SIZE_MB = 64;
+
+RPCCache::RPCCache() 
+{
+    m_blockHeight = chainActive.Height();
+    m_maxCacheSize = gArgs.GetArg("-rpccachesize", MAX_CACHE_SIZE_MB) * 1024 * 1024;
+}
+
 std::string RPCCache::MakeHashKey(const JSONRPCRequest& req)
 {
     std::string hashKey = req.strMethod;
@@ -18,6 +26,7 @@ void RPCCache::Clear()
 {
     LOCK(CacheMutex);
     m_cache.clear();
+    m_cacheSize = 0;
     m_blockHeight = chainActive.Height();
 
     LogPrint(BCLog::RPC, "RPC cache cleared.\n");
@@ -28,12 +37,23 @@ void RPCCache::Put(const std::string& path, const UniValue& content)
     if (chainActive.Height() > m_blockHeight)
         this->Clear();
 
+    int size = path.size() + content.write().size();
+
+    if (m_maxCacheSize < size + m_cacheSize) {
+        LogPrint(BCLog::RPC, "RPC cache over size limit: current = %d, max = %d\n", size + m_cacheSize, m_maxCacheSize);
+        return;
+    }
+
     LOCK(CacheMutex);
     if (m_cache.find(path) == m_cache.end()) {
-        LogPrint(BCLog::RPC, "RPC cache put '%s'\n", path);
+        LogPrint(BCLog::RPC, "RPC cache put '%s', size %d\n", path, size);
+        m_cacheSize += size;
         m_cache.emplace(path, content);
     } else {
         LogPrint(BCLog::RPC, "RPC cache put update '%s'\n", path);
+        // Adjust cache size, remove old element size, add new element size
+        m_cacheSize -= m_cache[path].size();
+        m_cacheSize += content.write().size();
         m_cache[path] = content;
     }
 }
@@ -55,7 +75,7 @@ UniValue RPCCache::Get(const std::string& path)
         return m_cache.at(path);
     }
 
-    /* Return empty UniValue if nothing found in cache. */
+    // Return empty UniValue if nothing found in cache.
     return UniValue();
 }
 
@@ -79,14 +99,7 @@ void RPCCache::PutRpcCache(const JSONRPCRequest& req, const UniValue& content)
 std::tuple<int64_t, int64_t> RPCCache::Statistic()
 {
     LOCK(CacheMutex);
+    LogPrint(BCLog::RPC, "RPC cache Statistic num elements = %d, size in bytes = %d", m_cache.size(), m_cacheSize);
 
-    int count = 0;
-    int64_t size = 0;
-    for (auto& it : m_cache)
-    {
-        count += 1;
-        size += it.first.size() + it.second.write().size();
-    }
-        
-    return { count, size };
+    return { (int64_t) m_cache.size(), (int64_t) m_cacheSize };
 }

--- a/src/rpc/cache.cpp
+++ b/src/rpc/cache.cpp
@@ -99,7 +99,6 @@ void RPCCache::PutRpcCache(const JSONRPCRequest& req, const UniValue& content)
 std::tuple<int64_t, int64_t> RPCCache::Statistic()
 {
     LOCK(CacheMutex);
-    LogPrint(BCLog::RPC, "RPC cache Statistic num elements = %d, size in bytes = %d", m_cache.size(), m_cacheSize);
-
+    // Return number of elements in cache and size of cache in bytes
     return { (int64_t) m_cache.size(), (int64_t) m_cacheSize };
 }

--- a/src/rpc/cache.h
+++ b/src/rpc/cache.h
@@ -17,6 +17,8 @@ private:
     Mutex CacheMutex;
     std::map<std::string, UniValue> m_cache;
     int m_blockHeight;
+    int m_cacheSize;
+    int m_maxCacheSize;
     const std::vector<std::string> supportedMethods = {"getlastcomments",
                                                        "getcomments",
                                                        "gettags",
@@ -42,10 +44,7 @@ private:
     std::string MakeHashKey(const JSONRPCRequest& req);
 
 public:
-    RPCCache() 
-    {
-        m_blockHeight = chainActive.Height();
-    }
+    RPCCache();
 
     void Clear();
 

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -79,7 +79,7 @@ void MilliSleep(int64_t n)
 std::string FormatISO8601DateTime(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER_CROSS
+#ifdef WIN32
     gmtime_s(&ts, &time_val);
 #else
     gmtime_r(&time_val, &ts);
@@ -90,7 +90,7 @@ std::string FormatISO8601DateTime(int64_t nTime) {
 std::string FormatISO8601Date(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER_CROSS
+#ifdef WIN32
     gmtime_s(&ts, &time_val);
 #else
     gmtime_r(&time_val, &ts);
@@ -101,7 +101,7 @@ std::string FormatISO8601Date(int64_t nTime) {
 std::string FormatISO8601Time(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER_CROSS
+#ifdef WIN32
     gmtime_s(&ts, &time_val);
 #else
     gmtime_r(&time_val, &ts);


### PR DESCRIPTION
Add -rpccachesize parameter to enable setting max memory available to RPC cache with a default value of 64MB.