### PR TITLE
Fix segmentation fault due to dereference of uninitialized pointer.

### DIFF
--- a/src/pocketdb/consensus/social/Post.hpp
+++ b/src/pocketdb/consensus/social/Post.hpp
@@ -36,7 +36,7 @@ namespace PocketConsensus
                 if (!relayOk && !CheckpointRepoInst.IsSocialCheckpoint(*ptx->GetHash(), *ptx->GetType(), SocialConsensusResult_RelayContentNotFound))
                     return {false, SocialConsensusResult_RelayContentNotFound};
 
-                if (*relayTx->GetType() == CONTENT_DELETE)
+                if (relayOk && *relayTx->GetType() == CONTENT_DELETE)
                     return {false, SocialConsensusResult_RepostDeletedContent};
             }
 

--- a/src/pocketdb/consensus/social/User.hpp
+++ b/src/pocketdb/consensus/social/User.hpp
@@ -182,7 +182,7 @@ namespace PocketConsensus
                 (ptx->GetReferrerAddress() ? ptx->GetReferrerAddress()->size() : 0) +
                 (ptx->GetPayloadPubkey() ? ptx->GetPayloadPubkey()->size() : 0);
 
-            if (dataSize > GetConsensusLimit(ConsensusLimit_max_user_size))
+            if (dataSize > (size_t) GetConsensusLimit(ConsensusLimit_max_user_size))
                 return {false, SocialConsensusResult_ContentSizeLimit};
 
             return Success;


### PR DESCRIPTION
Fix segmentation fault due to dereference of uninitialized pointer and fix compiler warning for signed/unsigned type comparison. 

This fix resolves this segmentation fault: https://github.com/pocketnetteam/pocketnet.core/issues/100