### PR TITLE
Add WSMutex to make accesses to WSConnections map thread safe.

### DIFF
--- a/src/pocketdb/web/PocketSystemRpc.cpp
+++ b/src/pocketdb/web/PocketSystemRpc.cpp
@@ -92,6 +92,7 @@ namespace PocketWeb::PocketWebRpc
 
         UniValue proxies(UniValue::VARR);
         if (!WSConnections.empty()) {
+            boost::lock_guard<boost::mutex> guard(WSMutex);
             for (auto& it : WSConnections) {
                 if (it.second.Service) {
                     UniValue proxy(UniValue::VOBJ);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -45,6 +45,8 @@
 #include "pocketdb/consensus/Helper.h"
 
 using WsServer = SimpleWeb::SocketServer<SimpleWeb::WS>;
+
+boost::mutex WSMutex;
 std::map<std::string, WSUser> WSConnections;
 
 #if defined(NDEBUG)
@@ -3407,6 +3409,8 @@ void CChainState::NotifyWSClients(const CBlock& block, CBlockIndex* blockIndex)
          sharesLang.pushKV(itl->first, itl->second);
      }
 
+
+     boost::lock_guard<boost::mutex> guard(WSMutex);
      for (auto& connWS : WSConnections)
      {
          UniValue msg(UniValue::VOBJ);

--- a/src/validation.h
+++ b/src/validation.h
@@ -34,11 +34,13 @@
 #include <vector>
 #include <atomic>
 #include <pubkey.h>
+#include <boost/thread/mutex.hpp>
 
 #include "websocket/ws.h"
 #include "pocketdb/helpers/TransactionHelper.h"
 using namespace PocketHelpers;
 
+extern boost::mutex WSMutex;
 extern std::map<std::string, WSUser> WSConnections;
 
 class CBlockIndex;


### PR DESCRIPTION
This patch fixes the segmentation fault caused by the non-threadsafe accesses to the WSConnections map.  A mutex is now acquired before accesses to the WSConnections map. 