### PR TITLE
Enable build of unittests from configure command line and add support for Github actions

### DIFF
--- a/.github/workflows/makecheck.yml
+++ b/.github/workflows/makecheck.yml
@@ -1,0 +1,36 @@
+name: make check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ $default-branch, 0.20, 0.21 ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: apt update
+      run: sudo apt-get update
+    - name: install libdb
+      run: sudo apt-get install libdb-dev libdb++-dev
+    - name: install boost
+      run: sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev
+    - name: Install dependencies
+      run: sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3 
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure --with-incompatible-bdb --enable-tests
+    - name: make
+      run: make -j2
+    - name: make check
+      run: make check
+    - name: make deploy
+      run: make deploy
+    - uses: actions/upload-artifact@v2
+      with:
+        name: package
+        path: pocketnet*.deb

--- a/.github/workflows/makecheck.yml
+++ b/.github/workflows/makecheck.yml
@@ -25,7 +25,9 @@ jobs:
     - name: autogen
       run: ./autogen.sh
     - name: configure
-      run: ./configure --with-incompatible-bdb --enable-tests
+      run: |
+        export BDB_PREFIX='/home/runner/work/pocketnet.core/pocketnet.core/db4'
+        ./configure --enable-tests BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
     - name: make
       run: make -j2
     - name: make check

--- a/.github/workflows/makecheck.yml
+++ b/.github/workflows/makecheck.yml
@@ -15,7 +15,9 @@ jobs:
     - name: apt update
       run: sudo apt-get update
     - name: install libdb
-      run: ./contrib/install_db4.sh `pwd`
+      run: |
+        chmod 777 ./contrib/install_db4.sh 
+        ./contrib/install_db4.sh `pwd`
     - name: install boost
       run: sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev
     - name: Install dependencies

--- a/.github/workflows/makecheck.yml
+++ b/.github/workflows/makecheck.yml
@@ -15,7 +15,7 @@ jobs:
     - name: apt update
       run: sudo apt-get update
     - name: install libdb
-      run: sudo apt-get install libdb-dev libdb++-dev
+      run: ./contrib/install_db4.sh `pwd`
     - name: install boost
       run: sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev
     - name: Install dependencies

--- a/configure.ac
+++ b/configure.ac
@@ -120,12 +120,12 @@ AC_ARG_ENABLE([upnp-default],
   [use_upnp_default=$enableval],
   [use_upnp_default=no])
 
-AC_ARG_ENABLE(tests,
-    AS_HELP_STRING([--disable-tests],[do not compile tests (default is to compile)]),
+AC_ARG_ENABLE([tests],
+    AS_HELP_STRING([--enable-tests],[compile tests (default is to not compile)]),
     [use_tests=$enableval],
-    [use_tests=yes])
+    [use_tests=no])
 
-AC_ARG_ENABLE(gui-tests,
+AC_ARG_ENABLE([gui-tests],
     AS_HELP_STRING([--disable-gui-tests],[do not compile GUI tests (default is to compile if GUI and tests enabled)]),
     [use_gui_tests=$enableval],
     [use_gui_tests=$use_tests])
@@ -1357,7 +1357,7 @@ AM_CONDITIONAL([BUILD_DARWIN], [test x$BUILD_OS = xdarwin])
 AM_CONDITIONAL([TARGET_WINDOWS], [test x$TARGET_OS = xwindows])
 AM_CONDITIONAL([TARGET_LINUX], [test x$TARGET_OS = xlinux])
 AM_CONDITIONAL([ENABLE_WALLET],[test x$enable_wallet = xyes])
-AM_CONDITIONAL([ENABLE_TESTS],[test x$BUILD_TEST = xno])
+AM_CONDITIONAL([ENABLE_TESTS],[test x$BUILD_TEST = xyes])
 AM_CONDITIONAL([ENABLE_QT],[test x$pocketcoin_enable_qt = xyes])
 AM_CONDITIONAL([ENABLE_QT_TESTS],[test x$BUILD_TEST_QT = xyes])
 AM_CONDITIONAL([ENABLE_BENCH],[test x$use_bench = xyes])


### PR DESCRIPTION
This pull request adds the --enable-tests parameter to configure script to enable building unittests.
Add makecheck.yml file which enabled GitHub actions to build project, run unittests via make check, create package and upload the package artifact to the test run.