### PR TITLE
Fix crash in pocketcoin-qt by checking if g_socket is initialized before dereference

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1741,7 +1741,7 @@ bool AppInitMain()
      * that the server is there and will be ready later).  Warmup mode will
      * be disabled when initialisation is finished.
      */
-    if (gArgs.GetBoolArg("-server", false))
+    if (gArgs.GetBoolArg("-server", true))
     {
         uiInterface.InitMessage_connect(SetRPCWarmupStatus);
         if (!AppInitServers())

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -211,7 +211,12 @@ class NodeImpl : public Node
         req.URI = uri;
         return g_socket->m_table_rpc.execute(req);
     }
-    std::vector<std::string> listRpcCommands() override { return g_socket->m_table_rpc.listCommands(); }
+    std::vector<std::string> listRpcCommands() override {
+        if (g_socket)
+            return g_socket->m_table_rpc.listCommands();
+        else
+            return vector<string>();;
+    }
     void rpcSetTimerInterfaceIfUnset(RPCTimerInterface* iface) override { RPCSetTimerInterfaceIfUnset(iface); }
     void rpcUnsetTimerInterface(RPCTimerInterface* iface) override { RPCUnsetTimerInterface(iface); }
     bool getUnspentOutput(const COutPoint& output, Coin& coin) override


### PR DESCRIPTION
- Set -server parameter to enabled by default to resolve program crashes with pocketcoin-qt