### PR TITLE
Extend Explorer RPC api for accumulative charts

### DIFF
--- a/src/pocketdb/repositories/web/ExplorerRepository.cpp
+++ b/src/pocketdb/repositories/web/ExplorerRepository.cpp
@@ -128,7 +128,7 @@ namespace PocketDb {
         TryTransactionStep(__func__, [&]()
         {
             auto stmt = SetupSqlStatement(R"sql(
-                select (u.Height / 1440)
+                select (u.Height / 60)
                   ,(
                     select
                       count()
@@ -138,7 +138,7 @@ namespace PocketDb {
                     and u1.Last = 1
                   )cnt
                 from Transactions u indexed by Transactions_Type_HeightByHour
-                where u.Type in (100)
+                where u.Type in (3)
                   and (u.Height / 60) <= (? / 60)
                   and (u.Height / 60) > (? / 60)
 
@@ -157,7 +157,7 @@ namespace PocketDb {
                 if (!okPart || !okCount)
                     continue;
 
-                result.pushKV(to_string(part), count);
+                result.pushKV(part, count);
             }
 
             FinalizeSqlStatement(*stmt);
@@ -185,7 +185,7 @@ namespace PocketDb {
 
                 from Transactions u indexed by Transactions_Type_HeightByDay
                 
-                where u.Type in (100)
+                where u.Type in (3)
                   and (u.Height / 1440) <= (? / 1440)
                   and (u.Height / 1440) > (? / 1440)
                 
@@ -198,13 +198,13 @@ namespace PocketDb {
 
             while (sqlite3_step(*stmt) == SQLITE_ROW)
             {
-                auto [okPart, part] = TryGetColumnInt(*stmt, 0);
+                auto [okPart, part] = TryGetColumnString(*stmt, 0);
                 auto [okCount, count] = TryGetColumnInt(*stmt, 1);
 
                 if (!okPart || !okCount)
                     continue;
 
-                result.pushKV(to_string(part), count);
+                result.pushKV(part, count);
             }
 
             FinalizeSqlStatement(*stmt);

--- a/src/pocketdb/repositories/web/ExplorerRepository.h
+++ b/src/pocketdb/repositories/web/ExplorerRepository.h
@@ -31,7 +31,10 @@ namespace PocketDb
         map<int, map<int, int>> GetBlocksStatistic(int bottomHeight, int topHeight);
         UniValue GetTransactionsStatisticByHours(int topHeight, int depth);
         UniValue GetTransactionsStatisticByDays(int topHeight, int depth);
+        UniValue GetContentStatisticByHours(int topHeight, int depth);
+        UniValue GetContentStatisticByDays(int topHeight, int depth);
         UniValue GetContentStatistic();
+        
         map<string, tuple<int, int64_t>> GetAddressesInfo(const vector<string>& hashes);
         UniValue GetAddressTransactions(const string& address, int pageInitBlock, int pageStart, int pageSize);
         UniValue GetBlockTransactions(const string& blockHash, int pageStart, int pageSize);

--- a/src/pocketdb/web/PocketExplorerRpc.cpp
+++ b/src/pocketdb/web/PocketExplorerRpc.cpp
@@ -52,15 +52,44 @@ namespace PocketWeb::PocketWebRpc
         return request.DbConnection()->ExplorerRepoInst->GetTransactionsStatisticByDays(topHeight, depth);
     }
 
-    UniValue GetStatisticContent(const JSONRPCRequest& request)
+    UniValue GetStatisticContentByHours(const JSONRPCRequest& request)
     {
         if (request.fHelp)
             throw std::runtime_error(
-                "getstatisticcontent\n"
-                "\nGet statistics for content transactions\n"
+                "getstatisticcontentbyhours\n"
+                "\nGet statistics for content transactions grouped by hours\n"
             );
 
-        return request.DbConnection()->ExplorerRepoInst->GetContentStatistic();
+        int topHeight = chainActive.Height() / 10 * 10;
+        if (request.params[0].isNum())
+            topHeight = std::min(request.params[0].get_int(), topHeight);
+
+        int depth = 24;
+        if (request.params[1].isNum())
+            depth = std::min(request.params[1].get_int(), depth);
+        depth = depth * 60;
+
+        return request.DbConnection()->ExplorerRepoInst->GetContentStatisticByHours(topHeight, depth);
+    }
+
+    UniValue GetStatisticContentByDays(const JSONRPCRequest& request)
+    {
+        if (request.fHelp)
+            throw std::runtime_error(
+                "getstatisticcontentbydays\n"
+                "\nGet statistics for content transactions grouped by days\n"
+            );
+
+        int topHeight = chainActive.Height() / 10 * 10;
+        if (request.params[0].isNum())
+            topHeight = std::min(request.params[0].get_int(), topHeight);
+
+        int depth = 30;
+        if (request.params[1].isNum())
+            depth = std::min(request.params[1].get_int(), depth);
+        depth = depth * 24 * 60;
+
+        return request.DbConnection()->ExplorerRepoInst->GetContentStatisticByDays(topHeight, depth);
     }
 
     UniValue GetLastBlocks(const JSONRPCRequest& request)

--- a/src/pocketdb/web/PocketExplorerRpc.h
+++ b/src/pocketdb/web/PocketExplorerRpc.h
@@ -17,7 +17,8 @@ namespace PocketWeb::PocketWebRpc
 
     UniValue GetStatisticByHours(const JSONRPCRequest& request);
     UniValue GetStatisticByDays(const JSONRPCRequest& request);
-    UniValue GetStatisticContent(const JSONRPCRequest& request);
+    UniValue GetStatisticContentByHours(const JSONRPCRequest& request);
+    UniValue GetStatisticContentByDays(const JSONRPCRequest& request);
     UniValue GetLastBlocks(const JSONRPCRequest& request);
     UniValue GetCompactBlock(const JSONRPCRequest& request);
     UniValue GetAddressInfo(const JSONRPCRequest& request);

--- a/src/pocketdb/web/PocketRpc.cpp
+++ b/src/pocketdb/web/PocketRpc.cpp
@@ -85,7 +85,8 @@ static const CRPCCommand commands[] =
     // Explorer
     {"explorer",       "getstatisticbyhours",              &GetStatisticByHours,            {"topHeight", "depth"}},
     {"explorer",       "getstatisticbydays",               &GetStatisticByDays,             {"topHeight", "depth"}},
-    {"explorer",       "getstatisticcontent",              &GetStatisticContent,            {}},
+    {"explorer",       "getstatisticcontentbyhours",       &GetStatisticContentByHours,     {"topHeight", "depth"}},
+    {"explorer",       "getstatisticcontentbydays",        &GetStatisticContentByDays,      {"topHeight", "depth"}},
     {"explorer",       "getaddressinfo",                   &GetAddressInfo,                 {"address"}},
     {"explorer",       "getcompactblock",                  &GetCompactBlock,                {"blockHash"}},
     {"explorer",       "getlastblocks",                    &GetLastBlocks,                  {"count", "lastHeight", "verbose"}},


### PR DESCRIPTION
Two methods have been added to calculate the number of accounts created in the context of days/hours:
- getstatisticcontentbyhours
- getstatisticcontentbydays