### PR TITLE
Fixes/0.20.19/feeds

### DIFF
--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -211,6 +211,9 @@ namespace PocketDb
                     where p.Type in (201) and p.Hash=p.String2 and p.String1=u.String1 and (p.Height>=? or p.Height isnull)) as VideoSpent,
 
                 (select count(1) from Transactions p indexed by Transactions_Type_String1_Height_Time_Int1
+                    where p.Type in (202) and p.Hash=p.String2 and p.String1=u.String1 and (p.Height>=? or p.Height isnull)) as ArticleSpent,
+
+                (select count(1) from Transactions p indexed by Transactions_Type_String1_Height_Time_Int1
                     where p.Type in (204) and p.String1=u.String1 and (p.Height>=? or p.Height isnull)) as CommentSpent,
 
                 (select count(1) from Transactions p indexed by Transactions_Type_String1_Height_Time_Int1
@@ -240,7 +243,8 @@ namespace PocketDb
             TryBindStatementInt(stmt, 4, heightWindow);
             TryBindStatementInt(stmt, 5, heightWindow);
             TryBindStatementInt(stmt, 6, heightWindow);
-            TryBindStatementText(stmt, 7, address);
+            TryBindStatementInt(stmt, 7, heightWindow);
+            TryBindStatementText(stmt, 8, address);
 
             if (sqlite3_step(*stmt) == SQLITE_ROW)
             {
@@ -252,10 +256,11 @@ namespace PocketDb
 
                 if (auto[ok, value] = TryGetColumnInt64(*stmt, 5); ok) result.pushKV("post_spent", value);
                 if (auto[ok, value] = TryGetColumnInt64(*stmt, 6); ok) result.pushKV("video_spent", value);
-                if (auto[ok, value] = TryGetColumnInt64(*stmt, 7); ok) result.pushKV("comment_spent", value);
-                if (auto[ok, value] = TryGetColumnInt64(*stmt, 8); ok) result.pushKV("score_spent", value);
-                if (auto[ok, value] = TryGetColumnInt64(*stmt, 9); ok) result.pushKV("comment_score_spent", value);
-                if (auto[ok, value] = TryGetColumnInt64(*stmt, 10); ok) result.pushKV("complain_spent", value);
+                if (auto[ok, value] = TryGetColumnInt64(*stmt, 7); ok) result.pushKV("article_spent", value);
+                if (auto[ok, value] = TryGetColumnInt64(*stmt, 8); ok) result.pushKV("comment_spent", value);
+                if (auto[ok, value] = TryGetColumnInt64(*stmt, 9); ok) result.pushKV("score_spent", value);
+                if (auto[ok, value] = TryGetColumnInt64(*stmt, 10); ok) result.pushKV("comment_score_spent", value);
+                if (auto[ok, value] = TryGetColumnInt64(*stmt, 12); ok) result.pushKV("complain_spent", value);
             }
 
             FinalizeSqlStatement(*stmt);

--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -3426,6 +3426,188 @@ namespace PocketDb
         return result;
     }
 
+    // TODO (o1q): Remove this method when the client gui switches to new methods
+    UniValue WebRpcRepository::GetProfileFeedOld(const string& addressFrom, const string& addressTo, int64_t topContentId,
+        int count, const string& lang, const vector<string>& tags, const vector<int>& contentTypes)
+    {
+        auto func = __func__;
+        UniValue result(UniValue::VARR);
+
+        if (addressTo.empty())
+            return result;
+
+        // ---------------------------------------------
+
+        string contentTypesFilter = join(vector<string>(contentTypes.size(), "?"), ",");
+
+        string topContentIdFilter;
+        if (topContentId > 0)
+            topContentIdFilter = " and t.Id < ? ";
+
+        string sql = R"sql(
+            select t.Id
+            from Transactions t indexed by Transactions_Type_Last_String1_Height_Id
+            where t.Type in ( )sql" + contentTypesFilter + R"sql( )
+                and t.Height > 0
+                and t.Last = 1
+                and t.String1 = ?
+                )sql" + topContentIdFilter + R"sql(
+        )sql";
+
+        if (!tags.empty())
+        {
+            sql += R"sql(
+                and t.id in (
+                    select tm.ContentId
+                    from web.Tags tag indexed by Tags_Lang_Value_Id
+                    join web.TagsMap tm indexed by TagsMap_TagId_ContentId
+                        on tag.Id = tm.TagId
+                    where tag.Value in ( )sql" + join(vector<string>(tags.size(), "?"), ",") + R"sql( )
+                )
+            )sql";
+        }
+
+        sql += " order by t.Id desc ";
+        sql += " limit ? ";
+
+        // ---------------------------------------------
+
+        vector<int64_t> ids;
+        TryTransactionStep(func, [&]()
+        {
+            auto stmt = SetupSqlStatement(sql);
+
+            int i = 1;
+            for (const auto& contenttype: contentTypes)
+                TryBindStatementInt(stmt, i++, contenttype);
+
+            TryBindStatementText(stmt, i++, addressTo);
+
+            if (topContentId > 0)
+                TryBindStatementInt64(stmt, i++, topContentId);
+
+            if (!tags.empty())
+                for (const auto& tag: tags)
+                    TryBindStatementText(stmt, i++, tag);
+
+            TryBindStatementInt(stmt, i++, count);
+
+            // ---------------------------------------------
+
+            while (sqlite3_step(*stmt) == SQLITE_ROW)
+            {
+                if (auto[ok, value] = TryGetColumnInt64(*stmt, 0); ok)
+                    ids.push_back(value);
+            }
+
+            FinalizeSqlStatement(*stmt);
+        });
+
+        if (ids.empty())
+            return result;
+
+        auto contents = GetContentsData(ids, addressFrom);
+        result.push_backV(contents);
+
+        return result;
+    }
+
+    // TODO (o1q): Remove this method when the client gui switches to new methods
+    UniValue WebRpcRepository::GetSubscribesFeedOld(const string& addressFrom, int64_t topContentId, int count,
+        const string& lang, const vector<string>& tags, const vector<int>& contentTypes)
+    {
+        auto func = __func__;
+        UniValue result(UniValue::VARR);
+
+        if (addressFrom.empty())
+            return result;
+
+        // ---------------------------------------------------
+
+        string contentTypesFilter = join(vector<string>(contentTypes.size(), "?"), ",");
+
+        string topContentIdFilter;
+        if (topContentId > 0)
+            topContentIdFilter = " and cnt.Id < ? ";
+
+        string sql = R"sql(
+            select cnt.Id
+
+            from Transactions cnt indexed by Transactions_Type_Last_String1_Height_Id
+
+            join Transactions subs indexed by Transactions_Type_Last_String1_String2_Height
+                on subs.Type in (302,303)
+               and subs.Last = 1
+               and subs.Height > 0
+               and subs.String1 = ?
+               and subs.String2 = cnt.String1
+
+            where cnt.Type in ( )sql" + contentTypesFilter + R"sql( )
+              and cnt.Last = 1
+              and cnt.Height > 0
+
+            )sql" + topContentIdFilter + R"sql(
+
+        )sql";
+
+        if (!tags.empty())
+        {
+            sql += R"sql(
+                and cnt.id in (
+                    select tm.ContentId
+                    from web.Tags tag indexed by Tags_Lang_Value_Id
+                    join web.TagsMap tm indexed by TagsMap_TagId_ContentId
+                        on tag.Id = tm.TagId
+                    where tag.Value in ( )sql" + join(vector<string>(tags.size(), "?"), ",") + R"sql( )
+                )
+            )sql";
+        }
+
+        sql += " order by cnt.Id desc ";
+        sql += " limit ? ";
+
+        // ---------------------------------------------------
+
+        vector<int64_t> ids;
+        TryTransactionStep(func, [&]()
+        {
+            int i = 1;
+            auto stmt = SetupSqlStatement(sql);
+
+            TryBindStatementText(stmt, i++, addressFrom);
+
+            for (const auto& contenttype: contentTypes)
+                TryBindStatementInt(stmt, i++, contenttype);
+
+            if (topContentId > 0)
+                TryBindStatementInt(stmt, i++, topContentId);
+
+            if (!tags.empty())
+                for (const auto& tag: tags)
+                    TryBindStatementText(stmt, i++, tag);
+
+            TryBindStatementInt(stmt, i++, count);
+
+            // ---------------------------------------------
+
+            while (sqlite3_step(*stmt) == SQLITE_ROW)
+            {
+                if (auto[ok, value] = TryGetColumnInt64(*stmt, 0); ok)
+                    ids.push_back(value);
+            }
+
+            FinalizeSqlStatement(*stmt);
+        });
+
+        if (ids.empty())
+            return result;
+
+        auto contents = GetContentsData(ids, addressFrom);
+        result.push_backV(contents);
+
+        return result;
+    }
+
     // ------------------------------------------------------
 
     vector<int64_t> WebRpcRepository::GetRandomContentIds(const string& lang, int count, int height)

--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -3301,27 +3301,27 @@ namespace PocketDb
 
         string sql = R"sql(
             select
-                t.Id,
-                tb.String2,
+                tc.Id contentId,
+                tb.String2 contentHash,
                 sum(tb.Int1) as sumBoost
 
             from Transactions tb indexed by Transactions_Type_Last_String2_Height
             join Transactions tc indexed by Transactions_Type_Last_String2_Height
                 on tc.String2 = tb.String2 and tc.Last = 1 and tc.Type in )sql" + contentTypesWhere + R"sql( and tc.Height > 0
-                and tc.String3 is null--?????
+                --and tc.String3 is null--?????
 
             )sql" + langFilter + R"sql(
 
             join Transactions u indexed by Transactions_Type_Last_String1_Height_Id
-                on u.Type in (100) and u.Last = 1 and u.Height > 0 and u.String1 = t.String1
+                on u.Type in (100) and u.Last = 1 and u.Height > 0 and u.String1 = tc.String1
 
             left join Ratings ur indexed by Ratings_Type_Id_Last_Height
                 on ur.Type = 0 and ur.Last = 1 and ur.Id = u.Id
 
             where tb.Type = 208
                 and tb.Last in (0, 1)
-                and tb.Height > ?
                 and tb.Height <= ?
+                and tb.Height > ?
 
                 -- Do not show posts from users with low reputation
                 and ifnull(ur.Value,0) > ?
@@ -3356,7 +3356,7 @@ namespace PocketDb
              ) )sql";
         }
 
-        sql += " group by tb.String2";
+        sql += " group by tc.Id, tb.String2";
         sql += " order by sum(tb.Int1) desc";
 
         // ---------------------------------------------
@@ -3405,6 +3405,7 @@ namespace PocketDb
             }
 
             // ---------------------------------------------
+            LogPrintf(sqlite3_expanded_sql(*stmt));
 
             while (sqlite3_step(*stmt) == SQLITE_ROW)
             {

--- a/src/pocketdb/repositories/web/WebRpcRepository.h
+++ b/src/pocketdb/repositories/web/WebRpcRepository.h
@@ -137,6 +137,10 @@ namespace PocketDb
 
         vector<int64_t> GetRandomContentIds(const string& lang, int count, int height);
 
+        // TODO (o1q): Remove this two methods when the client gui switches to new methods
+        UniValue GetProfileFeedOld(const string& addressFrom, const string& addressTo, int64_t topContentId, int count, const string& lang, const vector<string>& tags, const vector<int>& contentTypes);
+        UniValue GetSubscribesFeedOld(const string& addressFrom, int64_t topContentId, int count, const string& lang, const vector<string>& tags, const vector<int>& contentTypes);
+
     private:
         int cntBlocksForResult = 300;
         int cntPrevPosts = 5;

--- a/src/pocketdb/web/PocketAccountRpc.cpp
+++ b/src/pocketdb/web/PocketAccountRpc.cpp
@@ -157,6 +157,7 @@ namespace PocketWeb::PocketWebRpc
 
         int64_t postLimit;
         int64_t videoLimit;
+        int64_t articleLimit;
         int64_t complainLimit;
         int64_t commentLimit;
         int64_t scoreCommentLimit;
@@ -166,6 +167,7 @@ namespace PocketWeb::PocketWebRpc
             case PocketConsensus::AccountMode_Trial:
                 postLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_trial_post);
                 videoLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_trial_video);
+                articleLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_trial_article);
                 complainLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_trial_complain);
                 commentLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_trial_comment);
                 scoreCommentLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_trial_comment_score);
@@ -174,6 +176,7 @@ namespace PocketWeb::PocketWebRpc
             case PocketConsensus::AccountMode_Full:
                 postLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_full_post);
                 videoLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_full_video);
+                articleLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_full_article);
                 complainLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_full_complain);
                 commentLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_full_comment);
                 scoreCommentLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_full_comment_score);
@@ -182,6 +185,7 @@ namespace PocketWeb::PocketWebRpc
             case PocketConsensus::AccountMode_Pro:
                 postLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_full_post);
                 videoLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_pro_video);
+                articleLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_full_article);
                 complainLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_full_complain);
                 commentLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_full_comment);
                 scoreCommentLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_full_comment_score);
@@ -194,6 +198,9 @@ namespace PocketWeb::PocketWebRpc
 
         if (!result["video_spent"].isNull())
             result.pushKV("video_unspent", videoLimit - result["video_spent"].get_int());
+
+        if (!result["article_spent"].isNull())
+            result.pushKV("article_unspent", articleLimit - result["article_spent"].get_int());
 
         if (!result["complain_spent"].isNull())
             result.pushKV("complain_unspent", complainLimit - result["complain_spent"].get_int());

--- a/src/pocketdb/web/PocketContentRpc.cpp
+++ b/src/pocketdb/web/PocketContentRpc.cpp
@@ -507,12 +507,62 @@ namespace PocketWeb::PocketWebRpc
         return result;
     }
 
+    // TODO (o1q): Remove this method when the client gui switches to new methods
     UniValue FeedSelector(const JSONRPCRequest& request)
     {
-        if (request.params.size() > 1 && request.params[1].isStr() && request.params[1].get_str() == "1")
-            return GetSubscribesFeed(request);
+        if (request.fHelp)
+        {
+            throw runtime_error(
+                "feedselector\n"
+                "\nOld method. Will be removed in future");
+        }
 
-        return GetProfileFeed(request);
+        string addressFrom;
+        if (request.params.size() > 0 && request.params[0].isStr())
+            addressFrom = request.params[0].get_str();
+
+        string addressTo = "";
+        if (request.params.size() > 1 && request.params[1].isStr())
+            addressTo = request.params[1].get_str();
+
+        string topContentHash;
+        if (request.params.size() > 2 && request.params[2].isStr())
+            topContentHash = request.params[2].get_str();
+
+        int count = 10;
+        if (request.params.size() > 3 && request.params[3].isNum())
+        {
+            count = request.params[3].get_int();
+            if (count > 10)
+                count = 10;
+        }
+
+        string lang = "";
+        if (request.params.size() > 4 && request.params[4].isStr())
+            lang = request.params[4].get_str();
+
+        vector<string> tags;
+        if (request.params.size() > 5)
+            ParseRequestTags(request.params[5], tags);
+
+        // content types
+        vector<int> contentTypes;
+        ParseRequestContentTypes(request.params[6], contentTypes);
+
+        int64_t topContentId = 0;
+        if (!topContentHash.empty())
+        {
+            auto ids = request.DbConnection()->WebRpcRepoInst->GetContentIds({ topContentHash });
+            if (!ids.empty())
+                topContentId = ids[0];
+        }
+
+        if (addressTo == "1")
+            //return GetSubscribesFeed(request);
+            return request.DbConnection()->WebRpcRepoInst->GetSubscribesFeedOld(addressFrom, topContentId, count, lang, tags, contentTypes);
+
+        //return GetProfileFeed(request);
+        return request.DbConnection()->WebRpcRepoInst->GetProfileFeedOld(addressFrom, addressTo, topContentId, count, lang, tags, contentTypes);
     }
 
     UniValue GetContentsStatistic(const JSONRPCRequest& request)


### PR DESCRIPTION
- [Fixed typo in WebRpcRepository::GetBoostFeed](https://github.com/pocketnetteam/pocketnet.core/commit/e3777f0ee518c8d0553a874cd348ef547cf721b8)
- [Restored old methods GetProfileFeed & GetSubscribesFeed for old client's gui](https://github.com/pocketnetteam/pocketnet.core/commit/188daf74242cd7a8f81f525e004e00fdb70f1446)[](https://github.com/only1question)
- [Added restrictions on articles in the account profile](https://github.com/pocketnetteam/pocketnet.core/commit/85f065465829a0c07920a7e82d6d8a5139bfe401)