### PR TITLE
Fix nodeState view object

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -64,7 +64,7 @@ static constexpr int STALE_RELAY_AGE_LIMIT = 30 * 24 * 60 * 60;
 /// limiting block relay. Set to one week, denominated in seconds.
 static constexpr int HISTORICAL_BLOCK_AGE = 7 * 24 * 60 * 60;
 
-CCriticalSection cs_nodestate;
+// CCriticalSection cs_nodestate;
 
 struct COrphanTx {
     // When modifying, adapt the copy of this definition in tests/DoS_tests.
@@ -405,7 +405,7 @@ static CNodeState* State(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     return _state(pnode);
 }
 
-static CNodeState* StateView(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_nodestate)
+static CNodeState* StateView(NodeId pnode) // EXCLUSIVE_LOCKS_REQUIRED(cs_nodestate)
 {
     return _state(pnode);
 }
@@ -721,7 +721,7 @@ void PeerLogicValidation::InitializeNode(CNode* pnode)
     
     {
         LOCK(cs_main);
-        LOCK(cs_nodestate);
+        //LOCK(cs_nodestate);
         mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(addr, std::move(addrName)));
     }
 
@@ -755,7 +755,7 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
     assert(g_outbound_peers_with_protect_from_disconnect >= 0);
 
     {
-        LOCK(cs_nodestate);
+        //LOCK(cs_nodestate);
         mapNodeState.erase(nodeid);
     }
     
@@ -789,7 +789,7 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats)
 
 bool GetNodeStateStatsView(NodeId nodeid, CNodeStateStats& stats)
 {
-    LOCK(cs_nodestate);
+    //LOCK(cs_nodestate);
 
     CNodeState* state = StateView(nodeid);
     if (state == nullptr)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -64,7 +64,7 @@ static constexpr int STALE_RELAY_AGE_LIMIT = 30 * 24 * 60 * 60;
 /// limiting block relay. Set to one week, denominated in seconds.
 static constexpr int HISTORICAL_BLOCK_AGE = 7 * 24 * 60 * 60;
 
-// CCriticalSection cs_nodestate;
+CCriticalSection cs_nodestate;
 
 struct COrphanTx {
     // When modifying, adapt the copy of this definition in tests/DoS_tests.
@@ -405,7 +405,7 @@ static CNodeState* State(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     return _state(pnode);
 }
 
-static CNodeState* StateView(NodeId pnode) // EXCLUSIVE_LOCKS_REQUIRED(cs_nodestate)
+static CNodeState* StateView(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_nodestate)
 {
     return _state(pnode);
 }
@@ -721,7 +721,7 @@ void PeerLogicValidation::InitializeNode(CNode* pnode)
     
     {
         LOCK(cs_main);
-        //LOCK(cs_nodestate);
+        LOCK(cs_nodestate);
         mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(addr, std::move(addrName)));
     }
 
@@ -755,7 +755,7 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
     assert(g_outbound_peers_with_protect_from_disconnect >= 0);
 
     {
-        //LOCK(cs_nodestate);
+        LOCK(cs_nodestate);
         mapNodeState.erase(nodeid);
     }
     
@@ -789,8 +789,7 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats)
 
 bool GetNodeStateStatsView(NodeId nodeid, CNodeStateStats& stats)
 {
-    //LOCK(cs_nodestate);
-
+    LOCK(cs_nodestate);
     CNodeState* state = StateView(nodeid);
     if (state == nullptr)
         return false;

--- a/src/pocketdb/consensus/Reputation.h
+++ b/src/pocketdb/consensus/Reputation.h
@@ -11,7 +11,6 @@ namespace PocketConsensus
 {
     using namespace std;
 
-    // ------------------------------------------
     // Consensus checkpoint at 0 block
     class ReputationConsensus : public BaseConsensus
     {

--- a/src/pocketdb/repositories/ChainRepository.cpp
+++ b/src/pocketdb/repositories/ChainRepository.cpp
@@ -474,7 +474,7 @@ namespace PocketDb
         TryBindStatementInt(stmt, 1, height);
         TryBindStatementInt(stmt, 2, height);
 
-        LogPrintf("RestoreOldLast 1 %s\n", sqlite3_expanded_sql(stmt));
+        LogPrintf("RestoreOldLast 1 %s\n", sqlite3_expanded_sql(*stmt));
         TryStepStatement(stmt);
 
         int64_t nTime2 = GetTimeMicros();
@@ -499,7 +499,7 @@ namespace PocketDb
         TryBindStatementInt(stmt2, 1, height);
         TryBindStatementInt(stmt2, 2, height);
 
-        LogPrintf("RestoreOldLast 2 %s\n", sqlite3_expanded_sql(stmt2));
+        LogPrintf("RestoreOldLast 2 %s\n", sqlite3_expanded_sql(*stmt2));
         TryStepStatement(stmt2);
 
         int64_t nTime3 = GetTimeMicros();
@@ -522,7 +522,7 @@ namespace PocketDb
         TryBindStatementInt(stmt3, 1, height);
         TryBindStatementInt(stmt3, 2, height);
 
-        LogPrintf("RestoreOldLast 3 %s\n", sqlite3_expanded_sql(stmt3));
+        LogPrintf("RestoreOldLast 3 %s\n", sqlite3_expanded_sql(*stmt3));
         TryStepStatement(stmt3);
 
         int64_t nTime4 = GetTimeMicros();

--- a/src/pocketdb/repositories/ChainRepository.cpp
+++ b/src/pocketdb/repositories/ChainRepository.cpp
@@ -473,8 +473,6 @@ namespace PocketDb
         )sql");
         TryBindStatementInt(stmt, 1, height);
         TryBindStatementInt(stmt, 2, height);
-
-        LogPrintf("RestoreOldLast 1 %s\n", sqlite3_expanded_sql(*stmt));
         TryStepStatement(stmt);
 
         int64_t nTime2 = GetTimeMicros();
@@ -498,8 +496,6 @@ namespace PocketDb
         )sql");
         TryBindStatementInt(stmt2, 1, height);
         TryBindStatementInt(stmt2, 2, height);
-
-        LogPrintf("RestoreOldLast 2 %s\n", sqlite3_expanded_sql(*stmt2));
         TryStepStatement(stmt2);
 
         int64_t nTime3 = GetTimeMicros();
@@ -521,8 +517,6 @@ namespace PocketDb
         )sql");
         TryBindStatementInt(stmt3, 1, height);
         TryBindStatementInt(stmt3, 2, height);
-
-        LogPrintf("RestoreOldLast 3 %s\n", sqlite3_expanded_sql(*stmt3));
         TryStepStatement(stmt3);
 
         int64_t nTime4 = GetTimeMicros();

--- a/src/pocketdb/repositories/ChainRepository.cpp
+++ b/src/pocketdb/repositories/ChainRepository.cpp
@@ -473,6 +473,8 @@ namespace PocketDb
         )sql");
         TryBindStatementInt(stmt, 1, height);
         TryBindStatementInt(stmt, 2, height);
+
+        LogPrintf("RestoreOldLast 1 %s\n", sqlite3_expanded_sql(stmt));
         TryStepStatement(stmt);
 
         int64_t nTime2 = GetTimeMicros();
@@ -496,6 +498,8 @@ namespace PocketDb
         )sql");
         TryBindStatementInt(stmt2, 1, height);
         TryBindStatementInt(stmt2, 2, height);
+
+        LogPrintf("RestoreOldLast 2 %s\n", sqlite3_expanded_sql(stmt2));
         TryStepStatement(stmt2);
 
         int64_t nTime3 = GetTimeMicros();
@@ -517,6 +521,8 @@ namespace PocketDb
         )sql");
         TryBindStatementInt(stmt3, 1, height);
         TryBindStatementInt(stmt3, 2, height);
+
+        LogPrintf("RestoreOldLast 3 %s\n", sqlite3_expanded_sql(stmt3));
         TryStepStatement(stmt3);
 
         int64_t nTime4 = GetTimeMicros();

--- a/src/pocketdb/repositories/ConsensusRepository.cpp
+++ b/src/pocketdb/repositories/ConsensusRepository.cpp
@@ -763,7 +763,7 @@ namespace PocketDb
         string sql = R"sql(
             select count(1)
             from Transactions c indexed by Transactions_Type_Last_String1_String2_Height
-            join Transactions s indexed by Transactions_Type_String1_String2_Height
+            join Transactions s indexed by Transactions_Type_String1_Height_Time_Int1
                 on  s.String2 = c.String2
                 and s.Type in (300)
                 and s.Height <= ?
@@ -791,8 +791,6 @@ namespace PocketDb
             TryBindStatementText(stmt, i++, scoreData->ScoreTxHash);
             TryBindStatementText(stmt, i++, scoreData->ContentAddressHash);
 
-            LogPrintf("GetScoreContentCount: %s\n", sqlite3_expanded_sql(*stmt));
-
             if (sqlite3_step(*stmt) == SQLITE_ROW)
                 if (auto[ok, value] = TryGetColumnInt(*stmt, 0); ok)
                     result = value;
@@ -818,7 +816,7 @@ namespace PocketDb
         string sql = R"sql(
             select count(1)
             from Transactions c indexed by Transactions_Type_Last_String1_Height_Id
-            join Transactions s indexed by Transactions_Type_String1_String2_Height
+            join Transactions s indexed by Transactions_Type_String1_Height_Time_Int1
                 on  s.String2 = c.String2
                 and s.Type in (301)
                 and s.Height <= ?
@@ -846,8 +844,6 @@ namespace PocketDb
             TryBindStatementInt64(stmt, i++, (int64_t) scoreData->ScoreTime - scoresOneToOneDepth);
             TryBindStatementText(stmt, i++, scoreData->ScoreTxHash);
             TryBindStatementText(stmt, i++, scoreData->ContentAddressHash);
-
-            LogPrintf("GetScoreCommentCount: %s\n", sqlite3_expanded_sql(*stmt));
 
             if (sqlite3_step(*stmt) == SQLITE_ROW)
                 if (auto[ok, value] = TryGetColumnInt(*stmt, 0); ok)

--- a/src/pocketdb/repositories/ConsensusRepository.cpp
+++ b/src/pocketdb/repositories/ConsensusRepository.cpp
@@ -791,6 +791,8 @@ namespace PocketDb
             TryBindStatementText(stmt, i++, scoreData->ScoreTxHash);
             TryBindStatementText(stmt, i++, scoreData->ContentAddressHash);
 
+            LogPrintf("GetScoreContentCount: %s\n", sqlite3_expanded_sql(*stmt));
+
             if (sqlite3_step(*stmt) == SQLITE_ROW)
                 if (auto[ok, value] = TryGetColumnInt(*stmt, 0); ok)
                     result = value;
@@ -844,6 +846,8 @@ namespace PocketDb
             TryBindStatementInt64(stmt, i++, (int64_t) scoreData->ScoreTime - scoresOneToOneDepth);
             TryBindStatementText(stmt, i++, scoreData->ScoreTxHash);
             TryBindStatementText(stmt, i++, scoreData->ContentAddressHash);
+
+            LogPrintf("GetScoreCommentCount: %s\n", sqlite3_expanded_sql(*stmt));
 
             if (sqlite3_step(*stmt) == SQLITE_ROW)
                 if (auto[ok, value] = TryGetColumnInt(*stmt, 0); ok)

--- a/src/pocketdb/repositories/ConsensusRepository.cpp
+++ b/src/pocketdb/repositories/ConsensusRepository.cpp
@@ -762,20 +762,20 @@ namespace PocketDb
         // Build sql string
         string sql = R"sql(
             select count(1)
-            from Transactions c indexed by Transactions_Type_Last_String1_String2_Height
-            join Transactions s indexed by Transactions_Type_String1_Height_Time_Int1
-                on  s.String2 = c.String2
-                and s.Type in (300)
-                and s.Height <= ?
-                and s.String1 = ?
-                and s.Time < ?
-                and s.Time >= ?
-                and s.Int1 in ( )sql" + join(values | transformed(static_cast<std::string(*)(int)>(std::to_string)), ",") + R"sql( )
-                and s.Hash != ?
-            where c.Type in (200,201,202,207)
-              and c.String1 = ?
-              and c.Height is not null
-              and c.Last = 1
+            from Transactions s indexed by Transactions_Type_String1_Height_Time_Int1
+            cross join Transactions c indexed by Transactions_Type_Last_String1_String2_Height
+                on c.Type in (200,201,202,207)
+               and c.String1 = ?
+               and c.Height is not null
+               and c.Last = 1
+            where s.String2 = c.String2
+              and s.Type in (300)
+              and s.Height <= ?
+              and s.String1 = ?
+              and s.Time < ?
+              and s.Time >= ?
+              and s.Int1 in ( )sql" + join(values | transformed(static_cast<std::string(*)(int)>(std::to_string)), ",") + R"sql( )
+              and s.Hash != ?
         )sql";
 
         // Execute
@@ -790,8 +790,6 @@ namespace PocketDb
             TryBindStatementInt64(stmt, i++, scoreData->ScoreTime - scoresOneToOneDepth);
             TryBindStatementText(stmt, i++, scoreData->ScoreTxHash);
             TryBindStatementText(stmt, i++, scoreData->ContentAddressHash);
-
-            LogPrintf("%s: %s\n", __func__, sqlite3_expanded_sql(*stmt));
 
             if (sqlite3_step(*stmt) == SQLITE_ROW)
                 if (auto[ok, value] = TryGetColumnInt(*stmt, 0); ok)
@@ -817,21 +815,21 @@ namespace PocketDb
         // Build sql string
         string sql = R"sql(
             select count(1)
-            from Transactions c indexed by Transactions_Type_Last_String1_Height_Id
-            join Transactions s indexed by Transactions_Type_String1_Height_Time_Int1
-                on  s.String2 = c.String2
-                and s.Type in (301)
-                and s.Height <= ?
-                and s.String1 = ?
-                and s.Height is not null
-                and s.Time < ?
-                and s.Time >= ?
-                and s.Int1 in ( )sql" + join(values | transformed(static_cast<std::string(*)(int)>(std::to_string)), ",") + R"sql( )
-                and s.Hash != ?
-            where c.Type in (204, 205, 206)
-              and c.Height is not null
-              and c.String1 = ?
-              and c.Last = 1
+            from Transactions s indexed by Transactions_Type_String1_Height_Time_Int1
+            cross join Transactions c indexed by Transactions_Type_Last_String1_String2_Height
+                on c.Type in (204, 205, 206)
+               and c.Height is not null
+               and c.String1 = ?
+               and c.Last = 1
+            where s.String2 = c.String2
+              and s.Type in (301)
+              and s.Height <= ?
+              and s.String1 = ?
+              and s.Height is not null
+              and s.Time < ?
+              and s.Time >= ?
+              and s.Int1 in ( )sql" + join(values | transformed(static_cast<std::string(*)(int)>(std::to_string)), ",") + R"sql( )
+              and s.Hash != ?
         )sql";
 
         // Execute
@@ -846,8 +844,6 @@ namespace PocketDb
             TryBindStatementInt64(stmt, i++, (int64_t) scoreData->ScoreTime - scoresOneToOneDepth);
             TryBindStatementText(stmt, i++, scoreData->ScoreTxHash);
             TryBindStatementText(stmt, i++, scoreData->ContentAddressHash);
-
-            LogPrintf("%s: %s\n", __func__, sqlite3_expanded_sql(*stmt));
 
             if (sqlite3_step(*stmt) == SQLITE_ROW)
                 if (auto[ok, value] = TryGetColumnInt(*stmt, 0); ok)

--- a/src/pocketdb/repositories/ConsensusRepository.cpp
+++ b/src/pocketdb/repositories/ConsensusRepository.cpp
@@ -791,6 +791,8 @@ namespace PocketDb
             TryBindStatementText(stmt, i++, scoreData->ScoreTxHash);
             TryBindStatementText(stmt, i++, scoreData->ContentAddressHash);
 
+            LogPrintf("%s: %s\n", __func__, sqlite3_expanded_sql(*stmt));
+
             if (sqlite3_step(*stmt) == SQLITE_ROW)
                 if (auto[ok, value] = TryGetColumnInt(*stmt, 0); ok)
                     result = value;
@@ -844,6 +846,8 @@ namespace PocketDb
             TryBindStatementInt64(stmt, i++, (int64_t) scoreData->ScoreTime - scoresOneToOneDepth);
             TryBindStatementText(stmt, i++, scoreData->ScoreTxHash);
             TryBindStatementText(stmt, i++, scoreData->ContentAddressHash);
+
+            LogPrintf("%s: %s\n", __func__, sqlite3_expanded_sql(*stmt));
 
             if (sqlite3_step(*stmt) == SQLITE_ROW)
                 if (auto[ok, value] = TryGetColumnInt(*stmt, 0); ok)

--- a/src/pocketdb/repositories/web/NotifierRepository.cpp
+++ b/src/pocketdb/repositories/web/NotifierRepository.cpp
@@ -139,7 +139,7 @@ namespace PocketDb
             {
                 if (auto[ok, value] = TryGetColumnString(*stmt, 0); ok) result.pushKV("hash", value);
                 if (auto[ok, value] = TryGetColumnString(*stmt, 1); ok) result.pushKV("boostAddress", value);
-                if (auto[ok, value] = TryGetColumnInt64(*stmt, 2); ok) result.pushKV("boostAmount", value);
+                if (auto[ok, value] = TryGetColumnString(*stmt, 2); ok) result.pushKV("boostAmount", value);
                 if (auto[ok, value] = TryGetColumnString(*stmt, 3); ok) result.pushKV("boostName", value);
                 if (auto[ok, value] = TryGetColumnString(*stmt, 4); ok) result.pushKV("boostAvatar", value);
                 if (auto[ok, value] = TryGetColumnString(*stmt, 5); ok) result.pushKV("contentAddress", value);

--- a/src/pocketdb/web/PocketSystemRpc.cpp
+++ b/src/pocketdb/web/PocketSystemRpc.cpp
@@ -50,7 +50,6 @@ namespace PocketWeb::PocketWebRpc
             obj.pushKV("startingheight", stats.nStartingHeight);
             obj.pushKV("whitelisted", stats.fWhitelisted);
 
-            // Mutex guarded node statistic
             CNodeStateStats nodeState;
             if (GetNodeStateStatsView(stats.nodeid, nodeState))
             {

--- a/src/staker.cpp
+++ b/src/staker.cpp
@@ -101,11 +101,13 @@ void Staker::run(CChainParams const& chainparams, boost::thread_group& threadGro
 
         MilliSleep(minerSleep * 10);
     }
+
+    LogPrintf("Staker run thread exited\n");
 }
 
 void Staker::worker(CChainParams const& chainparams, std::string const& walletName)
 {
-    LogPrintf("Staker thread started for %s\n", walletName);
+    LogPrintf("Staker worker thread started for %s\n", walletName);
 
     RenameThread("coin-staker");
 
@@ -122,7 +124,7 @@ void Staker::worker(CChainParams const& chainparams, std::string const& walletNa
         if (!coinbaseScript || coinbaseScript->reserveScript.empty())
             throw std::runtime_error("No coinbase script available (staking requires a wallet)");
 
-        while (running || !ShutdownRequested())
+        while (running && !ShutdownRequested())
         {
             auto wallet = GetWallet(walletName);
 
@@ -195,12 +197,12 @@ void Staker::worker(CChainParams const& chainparams, std::string const& walletNa
     }
     catch (const boost::thread_interrupted&)
     {
-        LogPrintf("Pocketcoin Staker terminated\n");
+        LogPrintf("Staker worker thread terminated: %s\n", walletName);
         throw;
     }
     catch (const std::runtime_error& e)
     {
-        LogPrintf("Pocketcoin Staker runtime error: %s\n", e.what());
+        LogPrintf("Staker worker thread runtime error: %s: %s\n", walletName, e.what());
         return;
     }
 }


### PR DESCRIPTION
For the public version of the RPC getpeerinfo method, an attempt was made to create a new `mapNodeStateView` object, but the methods for updating information inside the object were forgotten. This fix removes `mapNodeStateView` and uses the `cs_nodestate` mutex in addition to `cs_main`