### PR TITLE
Shutdown fixes

### DIFF
--- a/src/eventloop.h
+++ b/src/eventloop.h
@@ -25,6 +25,8 @@ template<class T>
 class Queue
 {
 public:
+    using condCheck = std::function<bool()>;
+
     /**
     * Pop the next object from queue.
     * If queue is empty - blocks current thread until new value comes to queue
@@ -33,29 +35,27 @@ public:
     * @return true if element was filled
     * @return false if element was not filled
     */
-    bool GetNext(T& out)
+    bool GetNext(T& out, const condCheck& pre, const condCheck& post)
     {
-        if (shutdown) {
-            return false;
-        }
-
-        if (!GetPreConditionCheck()) {
-            return false;
-        }
-        
         WAIT_LOCK(m_mutex, lock);
+
+        if (pre) {
+            if (!pre()) {
+                return false;
+            }
+        }
 
         if (m_queue.empty()) {
             m_cv.wait(lock);
         }
 
-        if (m_queue.empty()) {
-            // Just return false because if we are here - queue waiting was interrupted and wi need to unblock waiting threads.
-            // False indicates that there is no out value and thread can call GetNext() again if it was not expected to interrupt.
-            return false;
+        if (post) {
+            if (!post) {
+                return false;
+            }
         }
 
-        if (!GetPostConditionCheck()) {
+        if (m_queue.empty()) {
             return false;
         }
 
@@ -79,9 +79,6 @@ public:
     void Interrupt()
     {
         LOCK(m_mutex);
-
-        shutdown = true;
-        
         // This just simply unblocks all threads that are waiting for value.
         // If there are multiple threads working with a single queue this will have the following workflow:
         // 1) All threads that are waiting in GetNext() will be unblocked.
@@ -97,29 +94,18 @@ public:
         return _Size();
     }
 
-    bool IsRunning()
-    {
-        return !shutdown;
-    }
-
     virtual ~Queue() = default;
 protected:
     // Override following methods to define special queue restrictions, e.x. max queue length.
     virtual bool AddConditionCheck() {
         return true;
     }
-    virtual bool GetPreConditionCheck() {
-        return true;
-    }
-    virtual bool GetPostConditionCheck() {
-        return true;
-    }
+
     size_t _Size()
     {
         return m_queue.size();
     }
 private:
-    bool shutdown = false;
     std::queue<T> m_queue;
     Mutex m_mutex;
     std::condition_variable m_cv;
@@ -197,15 +183,19 @@ public:
                 RenameThread(name->c_str());
             }
 
-            while (fRunning && queue->IsRunning())
+            // This is going to be executed after internal queue mutex lock to prevent
+            // stopping thread between this check and starting to wait.
+            auto preAndPostCheck = [&]() -> bool { return fRunning; };
+
+            while (fRunning)
             {
                 try
                 {
                     T entry;
-                    auto res = queue->GetNext(entry);
+                    auto res = queue->GetNext(entry, preAndPostCheck, preAndPostCheck);
                     
                     // If res is false - someone else interrupts queue and if current thread still wants to run just call GetNext() again
-                    if (res && fRunning)
+                    if (res)
                         queueProcessor->Process(std::forward<T>(entry));
                 }
                 catch (const std::exception& e)
@@ -222,11 +212,12 @@ public:
      */
     void Stop()
     {
-        m_fRunning = false;
-        m_queue->Interrupt();
-        
         LOCK(m_running_mutex);
-        
+        if (m_fRunning) {
+            m_fRunning = false;
+            m_queue->Interrupt();
+        }
+
         // Try join anyway because otherwise there could be a situation when thread is stopped but not joined
         // that is a bad practise.
         if (m_thread.joinable()) {

--- a/src/eventloop.h
+++ b/src/eventloop.h
@@ -50,7 +50,7 @@ public:
         }
 
         if (post) {
-            if (!post) {
+            if (!post()) {
                 return false;
             }
         }


### PR DESCRIPTION
Previously the thread checked for fRunning flag and only after that locked queue mutex and started to wait. So it was possible to call Stop in the time gap between thread checks the flag and starts to wait on conditional variable. That resulted in caller waiting to join thread and thread waiting for conditional variable.
The second problem was that if thread was waiting and was successfully interrupted, it popped element from queue and then shut down without processing that element.
Now, the check for fRunning is performed only after queue mutex is locked.
This results on following behavior:
- When thread is stopped after it checked for flag and before it start to wait:
  - it means that thread had already locked the mutex (opposite to previous version). 
  - The call to interrupt the queue is trying to lock this mutex too.
  - The thread is unlocking mutex only after is starts to wait. 
  - Interrupting call get mutex lock and call interrupt on thread that is guaranteed to be waiting on conditional variable.

I also remove the logic of stopping queue itself because there can be a situation in the future when we need to stop only one of threads that are processing the queue and remain others to carry on processing. If this PR doesn't solve the issue, behavior to stop queue can be reverted