### PR TITLE
Fixed migration for multiple locks

### DIFF
--- a/src/pocketdb/repositories/ChainRepository.cpp
+++ b/src/pocketdb/repositories/ChainRepository.cpp
@@ -383,6 +383,7 @@ namespace PocketDb
                 and ut.String1 in (select b.String2 union select value from json_each(b.String3))
                 and ut.Height > 0
             where b.Type in (305) and b.Hash = ?
+                and not exists (select 1 from BlockingLists bl where bl.IdSource = us.Id and bl.IdTarget = ut.Id)
         )sql");
         TryBindStatementText(insListStmt, 1, txHash);
         TryStepStatement(insListStmt);

--- a/src/pocketdb/repositories/MigrationRepository.cpp
+++ b/src/pocketdb/repositories/MigrationRepository.cpp
@@ -47,8 +47,7 @@ namespace PocketDb
                   and not exists (select 1 from Transactions bc indexed by Transactions_Type_Last_String1_String2_Height
                                   where bc.Type in (306) and bc.Last = 1 and bc.String1 = b.String1
                                     and bc.String2 in (select b.String2 union select value from json_each(b.String3))
-                                    and bc.Height > 0
-                                    and bc.Id >= b.Id)
+                                    and bc.Height >= b.Height)
                   and not exists (select 1 from BlockingLists bl where bl.IdSource = us.Id and bl.IdTarget = ut.Id)
             )sql")
 
@@ -81,8 +80,7 @@ namespace PocketDb
                   and not exists (select 1 from Transactions bc indexed by Transactions_Type_Last_String1_String2_Height
                                   where bc.Type in (306) and bc.Last = 1 and bc.String1 = b.String1
                                     and bc.String2 in (select b.String2 union select value from json_each(b.String3))
-                                    and bc.Height > 0
-                                    and bc.Id >= b.Id)
+                                    and bc.Height >= b.Height)
                   and not exists (select 1 from BlockingLists bl where bl.IdSource = us.Id and bl.IdTarget = ut.Id)
                 limit 1
             )sql");


### PR DESCRIPTION
- [x] Added condition to IndexBlocking to avoid double insertion of checkpoint transactions
- [x] Fixing creation blocking list in migration process 