### PR TITLE
fix: wrong map key threshold_shark_reg_depth -> threshold_whale_reg_depth

### DIFF
--- a/src/pocketdb/consensus/Base.h
+++ b/src/pocketdb/consensus/Base.h
@@ -306,7 +306,7 @@ namespace PocketConsensus
             { NetworkTest, { {0, 0} } }
         } },
         { threshold_shark_likers_comment, {
-            { NetworkMain, { {0, 15}, {1862000, 25} } },
+            { NetworkMain, { {0, 15}, {1873500, 25} } },
             { NetworkTest, { {0, 1} } }
         } },
         { threshold_shark_likers_comment_answer, {
@@ -426,7 +426,7 @@ namespace PocketConsensus
             { NetworkTest, { {0, 30} } }
         } },
         { ConsensusLimit_full_score, {
-            { NetworkMain, { {0, 90}, {175600, 200}, {1757000, 60}, {1791787, 100}, {1862000, 200} } },
+            { NetworkMain, { {0, 90}, {175600, 200}, {1757000, 60}, {1791787, 100}, {1873500, 200} } },
             { NetworkTest, { {0, 200} } }
         } },
         { ConsensusLimit_full_complain, {
@@ -438,7 +438,7 @@ namespace PocketConsensus
             { NetworkTest, { {0, 300} } }
         } },
         { ConsensusLimit_full_comment_score, {
-            { NetworkMain, { {0, 600}, {1757000, 200}, {1862000, 300} } },
+            { NetworkMain, { {0, 600}, {1757000, 200}, {1873500, 300} } },
             { NetworkTest, { {0, 600} } }
         } },
         

--- a/src/pocketdb/consensus/Base.h
+++ b/src/pocketdb/consensus/Base.h
@@ -315,7 +315,7 @@ namespace PocketConsensus
         } },
         
         // Thresholds for obtaining badges - WHALE
-        { threshold_shark_reg_depth, {
+        { threshold_whale_reg_depth, {
             { NetworkMain, { {0, 207360} } },
             { NetworkTest, { {0, 1} } }
         } },

--- a/src/pocketdb/consensus/social/Blocking.hpp
+++ b/src/pocketdb/consensus/social/Blocking.hpp
@@ -193,7 +193,7 @@ namespace PocketConsensus
     protected:
         const vector<ConsensusCheckpoint<BlockingConsensus>> m_rules = {
             {       0,       0, [](int height) { return make_shared<BlockingConsensus>(height); }},
-            { 1862000, 1114500, [](int height) { return make_shared<BlockingConsensus_checkpoint_multiple_blocking>(height); }}, // TODO (o1q): set checkpoint height for multiple locks
+            { 1873500, 1114500, [](int height) { return make_shared<BlockingConsensus_checkpoint_multiple_blocking>(height); }}, // TODO (o1q): set checkpoint height for multiple locks
         };
     public:
         shared_ptr<BlockingConsensus> Instance(int height)

--- a/src/pocketdb/consensus/social/CommentDelete.hpp
+++ b/src/pocketdb/consensus/social/CommentDelete.hpp
@@ -153,7 +153,7 @@ namespace PocketConsensus
     private:
         const vector<ConsensusCheckpoint < CommentDeleteConsensus>> m_rules = {
             {       0,       0, [](int height) { return make_shared<CommentDeleteConsensus>(height); }},
-            { 1862000, 1155000, [](int height) { return make_shared<CommentDeleteConsensus_checkpoint_check_author>(height); }},
+            { 1873500, 1155000, [](int height) { return make_shared<CommentDeleteConsensus_checkpoint_check_author>(height); }},
         };
     public:
         shared_ptr<CommentDeleteConsensus> Instance(int height)

--- a/src/pocketdb/consensus/social/CommentEdit.hpp
+++ b/src/pocketdb/consensus/social/CommentEdit.hpp
@@ -226,7 +226,7 @@ namespace PocketConsensus
         const vector<ConsensusCheckpoint < CommentEditConsensus>> m_rules = {
             {       0,      -1, [](int height) { return make_shared<CommentEditConsensus>(height); }},
             { 1180000,       0, [](int height) { return make_shared<CommentEditConsensus_checkpoint_1180000>(height); }},
-            { 1862000, 1155000, [](int height) { return make_shared<CommentEditConsensus_checkpoint_check_author>(height); }},
+            { 1873500, 1155000, [](int height) { return make_shared<CommentEditConsensus_checkpoint_check_author>(height); }},
         };
     public:
         shared_ptr<CommentEditConsensus> Instance(int height)

--- a/src/pocketdb/web/PocketRpc.cpp
+++ b/src/pocketdb/web/PocketRpc.cpp
@@ -56,7 +56,7 @@ static const CRPCCommand commands[] =
     {"contents",        "getcontents",                      &GetContents,                   {"address"}},
     {"contents",        "getrandomcontents",                &GetRandomContents,             {}},
     {"contents",        "getcontentactions",                &GetContentActions,             {"contentHash"}},
-    {"contents",        "getnotifications",                 &GetNotifications,              {"height", "filters"}},
+    // {"contents",        "getnotifications",                 &GetNotifications,              {"height", "filters"}},
 
     // Tags
 //    {"artifacts", "searchtags",                       &gettemplate,                       {"search_string", "count"}},


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [X] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes
- Fix double key in consensus map
- Extend height for next fork

## Other comments:
The key was duplicated - a quick check showed that the first option was used.
It is necessary to check the full synchronization of the node to be sure
