### PR TITLE
refactor: build versioning

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2012-2016 The Bitcoin Core developers
+# Copyright (c) 2012-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -18,31 +18,27 @@ else
     exit 1
 fi
 
-git_check_in_repo() {
-    ! { git status --porcelain -uall --ignored "$@" 2>/dev/null || echo '??'; } | grep -q '?'
-}
-
-DESC=""
-SUFFIX=""
-if [ "${POCKETCOIN_GENBUILD_NO_GIT}" != "1" -a -e "$(which git 2>/dev/null)" -a "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] && git_check_in_repo share/genbuild.sh; then
+GIT_TAG=""
+GIT_COMMIT=""
+if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
     # clean 'dirty' status of touched files that haven't been modified
-    git diff >/dev/null 2>/dev/null 
+    git diff >/dev/null 2>/dev/null
 
     # if latest commit is tagged and not dirty, then override using the tag name
     RAWDESC=$(git describe --abbrev=0 2>/dev/null)
     if [ "$(git rev-parse HEAD)" = "$(git rev-list -1 $RAWDESC 2>/dev/null)" ]; then
-        git diff-index --quiet HEAD -- && DESC=$RAWDESC
+        git diff-index --quiet HEAD -- && GIT_TAG=$RAWDESC
     fi
 
     # otherwise generate suffix from git, i.e. string like "59887e8-dirty"
-    SUFFIX=$(git rev-parse --short HEAD)
-    git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
+    GIT_COMMIT=$(git rev-parse --short HEAD)
+    git diff-index --quiet HEAD -- || GIT_COMMIT="$GIT_COMMIT-dirty"
 fi
 
-if [ -n "$DESC" ]; then
-    NEWINFO="#define BUILD_DESC \"$DESC\""
-elif [ -n "$SUFFIX" ]; then
-    NEWINFO="#define BUILD_SUFFIX $SUFFIX"
+if [ -n "$GIT_TAG" ]; then
+    NEWINFO="#define BUILD_GIT_TAG \"$GIT_TAG\""
+elif [ -n "$GIT_COMMIT" ]; then
+    NEWINFO="#define BUILD_GIT_COMMIT \"$GIT_COMMIT\""
 else
     NEWINFO="// No build information available"
 fi

--- a/share/genversion.sh
+++ b/share/genversion.sh
@@ -1,38 +1,46 @@
 #!/bin/sh
-# Copyright (c) 2012-2016 The Bitcoin Core developers
-# Copyright (c) 2018-20122The Pocketcoin Core developers
+# Copyright (c) 2012-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C
+if [ $# -gt 1 ]; then
+    cd "$2" || exit 1
+fi
+if [ $# -gt 0 ]; then
+    FILE="$1"
+    shift
+    if [ -f "$FILE" ]; then
+        INFO="$(head -n 1 "$FILE")"
+    fi
+else
+    echo "Usage: $0 <filename> <srcroot>"
+    exit 1
+fi
 
-git_check_in_repo() {
-    ! { git status --porcelain -uall --ignored "$@" 2>/dev/null || echo '??'; } | grep -q '?'
-}
-
-DESC=""
-SUFFIX=""
-if [ "${POCKETCOIN_GENBUILD_NO_GIT}" != "1" -a -e "$(which git 2>/dev/null)" -a "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] && git_check_in_repo share/genbuild.sh; then
+GIT_TAG=""
+GIT_COMMIT=""
+if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
     # clean 'dirty' status of touched files that haven't been modified
-    git diff >/dev/null 2>/dev/null 
+    git diff >/dev/null 2>/dev/null
 
     # if latest commit is tagged and not dirty, then override using the tag name
     RAWDESC=$(git describe --abbrev=0 2>/dev/null)
     if [ "$(git rev-parse HEAD)" = "$(git rev-list -1 $RAWDESC 2>/dev/null)" ]; then
-        git diff-index --quiet HEAD -- && DESC=$RAWDESC
+        git diff-index --quiet HEAD -- && GIT_TAG=$RAWDESC
     fi
 
     # otherwise generate suffix from git, i.e. string like "59887e8-dirty"
-    SUFFIX=$(git rev-parse --short HEAD)
-    git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
+    GIT_COMMIT=$(git rev-parse --short HEAD)
+    git diff-index --quiet HEAD -- || GIT_COMMIT="$GIT_COMMIT-dirty"
 fi
 
-if [ -n "$DESC" ]; then
-    NEWINFO=$DESC
-elif [ -n "$SUFFIX" ]; then
-    NEWINFO=$SUFFIX
+if [ -n "$GIT_TAG" ]; then
+    NEWINFO="#define BUILD_GIT_TAG \"$GIT_TAG\""
+elif [ -n "$GIT_COMMIT" ]; then
+    NEWINFO="#define BUILD_GIT_COMMIT \"$GIT_COMMIT\""
 else
-    NEWINFO="---"
+    NEWINFO="// No build information available"
 fi
 
 echo $NEWINFO

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -26,16 +26,11 @@ const std::string CLIENT_NAME("Satoshi");
 
 //! git will put "#define GIT_COMMIT_ID ..." on the next line inside archives. $Format:%n#define GIT_COMMIT_ID "%H"$
 
-// TODO (losty-fur): is it really needed?
-#define BUILD_GENERAL_VERSION(maj, min, rev) \
-    "v" DO_STRINGIZE(maj) "." DO_STRINGIZE(min) "." DO_STRINGIZE(rev)
-
 #ifdef BUILD_GIT_TAG
     #define BUILD_DESC BUILD_GIT_TAG
     #define BUILD_SUFFIX ""
 #else
-    #define BUILD_DESC "v" STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) \
-                       "." STRINGIZE(CLIENT_VERSION_REVISION) "." STRINGIZE(CLIENT_VERSION_BUILD)
+    #define BUILD_DESC STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_REVISION)
     #ifdef BUILD_GIT_COMMIT
         #define BUILD_SUFFIX "-" BUILD_GIT_COMMIT
     #elif defined(GIT_COMMIT_ID)


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [X] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Other comments:
For build without tag - X.Y.Z-{hash}
For build with tag - version from tag
