### PR TITLE
refactor: Use optional instead of shared_ptr where it is semantically correct

### DIFF
--- a/src/pocketdb/consensus/Social.h
+++ b/src/pocketdb/consensus/Social.h
@@ -125,17 +125,17 @@ namespace PocketConsensus
         }
 
         // Check empty pointer
-        bool IsEmpty(const shared_ptr<string>& ptr) const
+        bool IsEmpty(const optional<string>& ptr) const
         {
             return !ptr || (*ptr).empty();
         }
 
-        bool IsEmpty(const shared_ptr<int>& ptr) const
+        bool IsEmpty(const optional<int>& ptr) const
         {
             return !ptr;
         }
 
-        bool IsEmpty(const shared_ptr<int64_t>& ptr) const
+        bool IsEmpty(const optional<int64_t>& ptr) const
         {
             return !ptr;
         }

--- a/src/pocketdb/consensus/social/Article.hpp
+++ b/src/pocketdb/consensus/social/Article.hpp
@@ -5,6 +5,7 @@
 #ifndef POCKETCONSENSUS_ARTICLE_H
 #define POCKETCONSENSUS_ARTICLE_H
 
+#include "pocketdb/consensus/Reputation.h"
 #include "pocketdb/consensus/Social.h"
 #include "pocketdb/models/dto/content/Article.h"
 
@@ -148,7 +149,8 @@ namespace PocketConsensus
         virtual tuple<bool, SocialConsensusResult> ValidateLimit(const ArticleRef& ptx, int count)
         {
             auto reputationConsensus = PocketConsensus::ReputationConsensusFactoryInst.Instance(Height);
-            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*ptx->GetAddress());
+            auto address = ptx->GetAddress();
+            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*address);
             if (count >= GetLimit(mode))
             {
                 if (!CheckpointRepoInst.IsSocialCheckpoint(*ptx->GetHash(), *ptx->GetType(), SocialConsensusResult_ContentLimit))

--- a/src/pocketdb/consensus/social/Comment.hpp
+++ b/src/pocketdb/consensus/social/Comment.hpp
@@ -131,7 +131,8 @@ namespace PocketConsensus
         virtual ConsensusValidateResult ValidateLimit(const CommentRef& ptx, int count)
         {
             auto reputationConsensus = PocketConsensus::ReputationConsensusFactoryInst.Instance(Height);
-            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*ptx->GetAddress());
+            auto address = ptx->GetAddress();
+            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*address);
             if (count >= GetLimit(mode))
                 return {false, SocialConsensusResult_CommentLimit};
 

--- a/src/pocketdb/consensus/social/Complain.hpp
+++ b/src/pocketdb/consensus/social/Complain.hpp
@@ -129,7 +129,8 @@ namespace PocketConsensus
         virtual ConsensusValidateResult ValidateLimit(const ComplainRef& ptx, int count)
         {
             auto reputationConsensus = PocketConsensus::ReputationConsensusFactoryInst.Instance(Height);
-            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*ptx->GetAddress());
+            auto address = ptx->GetAddress();
+            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*address);
             if (count >= GetComplainsLimit(mode))
                 return {false, SocialConsensusResult_ComplainLimit};
 

--- a/src/pocketdb/consensus/social/Post.hpp
+++ b/src/pocketdb/consensus/social/Post.hpp
@@ -167,7 +167,8 @@ namespace PocketConsensus
         virtual tuple<bool, SocialConsensusResult> ValidateLimit(const PostRef& ptx, int count)
         {
             auto reputationConsensus = PocketConsensus::ReputationConsensusFactoryInst.Instance(Height);
-            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*ptx->GetAddress());
+            auto address = ptx->GetAddress();
+            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*address);
             if (count >= GetLimit(mode))
             {
                 if (!CheckpointRepoInst.IsSocialCheckpoint(*ptx->GetHash(), *ptx->GetType(), SocialConsensusResult_ContentLimit))

--- a/src/pocketdb/consensus/social/ScoreComment.hpp
+++ b/src/pocketdb/consensus/social/ScoreComment.hpp
@@ -163,7 +163,8 @@ namespace PocketConsensus
         {
 
             auto reputationConsensus = PocketConsensus::ReputationConsensusFactoryInst.Instance(Height);
-            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*ptx->GetAddress());
+            auto address = ptx->GetAddress();
+            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*address);
             if (count >= GetScoresLimit(mode))
                 return {false, SocialConsensusResult_CommentScoreLimit};
 

--- a/src/pocketdb/consensus/social/ScoreContent.hpp
+++ b/src/pocketdb/consensus/social/ScoreContent.hpp
@@ -161,7 +161,8 @@ namespace PocketConsensus
         virtual ConsensusValidateResult ValidateLimit(const ScoreContentRef& ptx, int count)
         {
             auto reputationConsensus = PocketConsensus::ReputationConsensusFactoryInst.Instance(Height);
-            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*ptx->GetAddress());
+            auto address = ptx->GetAddress();
+            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*address);
             if (count >= GetScoresLimit(mode))
                 return {false, SocialConsensusResult_ScoreLimit};
 

--- a/src/pocketdb/consensus/social/Video.hpp
+++ b/src/pocketdb/consensus/social/Video.hpp
@@ -147,7 +147,8 @@ namespace PocketConsensus
         virtual ConsensusValidateResult ValidateLimit(const VideoRef& ptx, int count)
         {
             auto reputationConsensus = PocketConsensus::ReputationConsensusFactoryInst.Instance(Height);
-            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*ptx->GetAddress());
+            auto address = ptx->GetAddress();
+            auto[mode, reputation, balance] = reputationConsensus->GetAccountMode(*address);
             auto limit = GetLimit(mode);
 
             if (count >= limit)

--- a/src/pocketdb/models/base/Base.h
+++ b/src/pocketdb/models/base/Base.h
@@ -6,6 +6,7 @@
 #define POCKETTX_BASE_H
 
 #include <memory>
+#include <optional>
 #include "pocketdb/models/base/PocketTypes.h"
 #include <univalue/include/univalue.h>
 

--- a/src/pocketdb/models/base/Payload.cpp
+++ b/src/pocketdb/models/base/Payload.cpp
@@ -8,31 +8,31 @@ namespace PocketTx
 {
     Payload::Payload() {}
 
-    shared_ptr<string> Payload::GetTxHash() const { return m_txHash; }
-    void Payload::SetTxHash(string value) { m_txHash = make_shared<string>(value); }
+    const optional<string>& Payload::GetTxHash() const { return m_txHash; }
+    void Payload::SetTxHash(string value) { m_txHash = value; }
 
-    shared_ptr<string> Payload::GetString1() const { return m_string1; }
-    void Payload::SetString1(string value) { m_string1 = make_shared<string>(value); }
+    const optional<string>& Payload::GetString1() const { return m_string1; }
+    void Payload::SetString1(string value) { m_string1 = value; }
 
-    shared_ptr<string> Payload::GetString2() const { return m_string2; }
-    void Payload::SetString2(string value) { m_string2 = make_shared<string>(value); }
+    const optional<string>& Payload::GetString2() const { return m_string2; }
+    void Payload::SetString2(string value) { m_string2 = value; }
 
-    shared_ptr<string> Payload::GetString3() const { return m_string3; }
-    void Payload::SetString3(string value) { m_string3 = make_shared<string>(value); }
+    const optional<string>& Payload::GetString3() const { return m_string3; }
+    void Payload::SetString3(string value) { m_string3 = value; }
 
-    shared_ptr<string> Payload::GetString4() const { return m_string4; }
-    void Payload::SetString4(string value) { m_string4 = make_shared<string>(value); }
+    const optional<string>& Payload::GetString4() const { return m_string4; }
+    void Payload::SetString4(string value) { m_string4 = value; }
 
-    shared_ptr<string> Payload::GetString5() const { return m_string5; }
-    void Payload::SetString5(string value) { m_string5 = make_shared<string>(value); }
+    const optional<string>& Payload::GetString5() const { return m_string5; }
+    void Payload::SetString5(string value) { m_string5 = value; }
 
-    shared_ptr<string> Payload::GetString6() const { return m_string6; }
-    void Payload::SetString6(string value) { m_string6 = make_shared<string>(value); }
+    const optional<string>& Payload::GetString6() const { return m_string6; }
+    void Payload::SetString6(string value) { m_string6 = value; }
 
-    shared_ptr<string> Payload::GetString7() const { return m_string7; }
-    void Payload::SetString7(string value) { m_string7 = make_shared<string>(value); }
+    const optional<string>& Payload::GetString7() const { return m_string7; }
+    void Payload::SetString7(string value) { m_string7 = value; }
 
-    shared_ptr<int64_t> Payload::GetInt1() const { return m_int1; }
-    void Payload::SetInt1(int64_t value) { m_int1 = make_shared<int64_t>(value); }
+    const optional<int64_t>& Payload::GetInt1() const { return m_int1; }
+    void Payload::SetInt1(int64_t value) { m_int1 = value; }
 
 } // namespace PocketTx

--- a/src/pocketdb/models/base/Payload.h
+++ b/src/pocketdb/models/base/Payload.h
@@ -16,44 +16,44 @@ namespace PocketTx
     public:
         Payload();
 
-        shared_ptr<string> GetTxHash() const;
+        const optional<string>& GetTxHash() const;
         void SetTxHash(string value);
 
-        shared_ptr<string> GetString1() const;
+        const optional<string>& GetString1() const;
         void SetString1(string value);
 
-        shared_ptr<string> GetString2() const;
+        const optional<string>& GetString2() const;
         void SetString2(string value);
 
-        shared_ptr<string> GetString3() const;
+        const optional<string>& GetString3() const;
         void SetString3(string value);
 
-        shared_ptr<string> GetString4() const;
+        const optional<string>& GetString4() const;
         void SetString4(string value);
 
-        shared_ptr<string> GetString5() const;
+        const optional<string>& GetString5() const;
         void SetString5(string value);
 
-        shared_ptr<string> GetString6() const;
+        const optional<string>& GetString6() const;
         void SetString6(string value);
 
-        shared_ptr<string> GetString7() const;
+        const optional<string>& GetString7() const;
         void SetString7(string value);
 
-        shared_ptr<int64_t> GetInt1() const;
+        const optional<int64_t>& GetInt1() const;
         void SetInt1(int64_t value);
 
     protected:
 
-        shared_ptr<string> m_txHash = nullptr;
-        shared_ptr<string> m_string1 = nullptr;
-        shared_ptr<string> m_string2 = nullptr;
-        shared_ptr<string> m_string3 = nullptr;
-        shared_ptr<string> m_string4 = nullptr;
-        shared_ptr<string> m_string5 = nullptr;
-        shared_ptr<string> m_string6 = nullptr;
-        shared_ptr<string> m_string7 = nullptr;
-        shared_ptr<int64_t> m_int1 = nullptr;
+        optional<string> m_txHash = nullopt;
+        optional<string> m_string1 = nullopt;
+        optional<string> m_string2 = nullopt;
+        optional<string> m_string3 = nullopt;
+        optional<string> m_string4 = nullopt;
+        optional<string> m_string5 = nullopt;
+        optional<string> m_string6 = nullopt;
+        optional<string> m_string7 = nullopt;
+        optional<int64_t> m_int1 = nullopt;
 
     };
 

--- a/src/pocketdb/models/base/Rating.cpp
+++ b/src/pocketdb/models/base/Rating.cpp
@@ -6,15 +6,15 @@
 
 namespace PocketTx
 {
-    shared_ptr <RatingType> Rating::GetType() const { return m_type; }
-    void Rating::SetType(RatingType value) { m_type = make_shared<RatingType>(value); }
+    const optional <RatingType>& Rating::GetType() const { return m_type; }
+    void Rating::SetType(RatingType value) { m_type = value; }
 
-    shared_ptr<int> Rating::GetHeight() const { return m_height; }
-    void Rating::SetHeight(int value) { m_height = make_shared<int>(value); }
+    const optional <int>& Rating::GetHeight() const { return m_height; }
+    void Rating::SetHeight(int value) { m_height = value; }
 
-    shared_ptr <int64_t> Rating::GetId() const { return m_id; }
-    void Rating::SetId(int64_t value) { m_id = make_shared<int64_t>(value); }
+    const optional <int64_t>& Rating::GetId() const { return m_id; }
+    void Rating::SetId(int64_t value) { m_id = value; }
 
-    shared_ptr <int64_t> Rating::GetValue() const { return m_value; }
-    void Rating::SetValue(int64_t value) { m_value = make_shared<int64_t>(value); }
+    const optional <int64_t>& Rating::GetValue() const { return m_value; }
+    void Rating::SetValue(int64_t value) { m_value = value; }
 } // namespace PocketTx

--- a/src/pocketdb/models/base/Rating.h
+++ b/src/pocketdb/models/base/Rating.h
@@ -18,23 +18,23 @@ namespace PocketTx
         Rating() = default;
         ~Rating() = default;
 
-        shared_ptr<RatingType> GetType() const;
+        const optional <RatingType>& GetType() const;
         void SetType(RatingType value);
 
-        shared_ptr <int> GetHeight() const;
+        const optional <int>& GetHeight() const;
         void SetHeight(int value);
 
-        shared_ptr <int64_t> GetId() const;
+        const optional <int64_t>& GetId() const;
         void SetId(int64_t value);
 
-        shared_ptr <int64_t> GetValue() const;
+        const optional <int64_t>& GetValue() const;
         void SetValue(int64_t value);
 
     protected:
-        shared_ptr <RatingType> m_type = nullptr;
-        shared_ptr <int> m_height = nullptr;
-        shared_ptr <int64_t> m_id = nullptr;
-        shared_ptr <int64_t> m_value = nullptr;
+        optional <RatingType> m_type = nullopt;
+        optional <int> m_height = nullopt;
+        optional <int64_t> m_id = nullopt;
+        optional <int64_t> m_value = nullopt;
     };
 
 } // namespace PocketTx

--- a/src/pocketdb/models/base/SocialTransaction.cpp
+++ b/src/pocketdb/models/base/SocialTransaction.cpp
@@ -14,7 +14,7 @@ namespace PocketTx
     {
     }
 
-    shared_ptr<UniValue> SocialTransaction::Serialize() const
+    optional<UniValue> SocialTransaction::Serialize() const
     {
         auto result = Transaction::Serialize();
 
@@ -61,7 +61,7 @@ namespace PocketTx
         // Deserialize payload part if exists non-empty "p" object
         if (auto[pOk, pVal] = TryGetObj(src, "p"); pOk)
         {
-            m_payload = make_shared<Payload>();
+            m_payload = Payload();
             if (auto[ok, val] = TryGetStr(pVal, "h"); ok) m_payload->SetTxHash(val);
             if (auto[ok, val] = TryGetStr(pVal, "s1"); ok) m_payload->SetString1(val);
             if (auto[ok, val] = TryGetStr(pVal, "s2"); ok) m_payload->SetString2(val);
@@ -79,8 +79,8 @@ namespace PocketTx
         Deserialize(src);
     }
     
-    shared_ptr<string> SocialTransaction::GetAddress() const { return m_string1; }
-    void SocialTransaction::SetAddress(const string& value) { m_string1 = make_shared<string>(value); }
+    const optional<string>& SocialTransaction::GetAddress() const { return m_string1; }
+    void SocialTransaction::SetAddress(const string& value) { m_string1 = value; }
 
 } // namespace PocketTx
 

--- a/src/pocketdb/models/base/SocialTransaction.h
+++ b/src/pocketdb/models/base/SocialTransaction.h
@@ -15,11 +15,11 @@ namespace PocketTx
         SocialTransaction();
         SocialTransaction(const CTransactionRef& tx);
 
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;
 
-        shared_ptr<string> GetAddress() const;
+        const optional<string>& GetAddress() const;
         void SetAddress(const string& value);
         
     }; // class SocialTransaction

--- a/src/pocketdb/models/base/Transaction.cpp
+++ b/src/pocketdb/models/base/Transaction.cpp
@@ -17,15 +17,16 @@ namespace PocketTx
         SetTime(tx->nTime);
     }
 
-    shared_ptr<UniValue> Transaction::Serialize() const
+    optional<UniValue> Transaction::Serialize() const
     {
-        auto result = make_shared<UniValue>(UniValue(UniValue::VOBJ));
+        // TODO (losty): optional?
+        UniValue result (UniValue::VOBJ);
         
         // TODO (brangr): remove safe?        
-        result->pushKV("txid", *GetHash());
-        result->pushKV("time", *GetTime());
-        result->pushKV("block", 0);
-        result->pushKV("last", false);
+        result.pushKV("txid", *GetHash());
+        result.pushKV("time", *GetTime());
+        result.pushKV("block", 0);
+        result.pushKV("last", false);
 
         return result;
     }
@@ -39,53 +40,54 @@ namespace PocketTx
         GeneratePayload();
     }
 
-    shared_ptr<string> Transaction::GetHash() const { return m_hash; }
-    void Transaction::SetHash(string value) { m_hash = make_shared<string>(value); }
-    bool Transaction::operator==(const string& hash) const { return *m_hash == hash; }
+    const optional<string>& Transaction::GetHash() const { return m_hash; }
+    void Transaction::SetHash(string value) { m_hash = value; }
+    bool Transaction::operator==(const string& hash) const { return m_hash && *m_hash == hash; }
 
-    shared_ptr<TxType> Transaction::GetType() const { return m_type; }
-    void Transaction::SetType(TxType value) { m_type = make_shared<TxType>(value); }
+    const optional<TxType>& Transaction::GetType() const { return m_type; }
+    void Transaction::SetType(TxType value) { m_type = value; }
 
-    shared_ptr<int64_t> Transaction::GetTime() const { return m_time; }
-    void Transaction::SetTime(int64_t value) { m_time = make_shared<int64_t>(value); }
+    const optional<int64_t>& Transaction::GetTime() const { return m_time; }
+    void Transaction::SetTime(int64_t value) { m_time = value; }
 
-    shared_ptr<int64_t> Transaction::GetHeight() const { return m_height; }
-    void Transaction::SetHeight(int64_t value) { m_height = make_shared<int64_t>(value); }
+    const optional<int64_t>& Transaction::GetHeight() const { return m_height; }
+    void Transaction::SetHeight(int64_t value) { m_height = value; }
 
-    shared_ptr<string> Transaction::GetBlockHash() const { return m_blockhash; }
-    void Transaction::SetBlockHash(string value) { m_blockhash = make_shared<string>(value); }
+    const optional<string>& Transaction::GetBlockHash() const { return m_blockhash; }
+    void Transaction::SetBlockHash(string value) { m_blockhash = value; }
 
-    shared_ptr<bool> Transaction::GetLast() const { return m_last; }
-    void Transaction::SetLast(bool value) { m_last = make_shared<bool>(value); }
+    const optional<bool>& Transaction::GetLast() const { return m_last; }
+    void Transaction::SetLast(bool value) { m_last = value; }
 
-    shared_ptr<string> Transaction::GetString1() const { return m_string1; }
-    void Transaction::SetString1(string value) { m_string1 = make_shared<string>(value); }
+    const optional<string>& Transaction::GetString1() const { return m_string1; }
+    void Transaction::SetString1(string value) { m_string1 = value; }
 
-    shared_ptr<string> Transaction::GetString2() const { return m_string2; }
-    void Transaction::SetString2(string value) { m_string2 = make_shared<string>(value); }
+    const optional<string>& Transaction::GetString2() const { return m_string2; }
+    void Transaction::SetString2(string value) { m_string2 = value; }
 
-    shared_ptr<string> Transaction::GetString3() const { return m_string3; }
-    void Transaction::SetString3(string value) { m_string3 = make_shared<string>(value); }
+    const optional<string>& Transaction::GetString3() const { return m_string3; }
+    void Transaction::SetString3(string value) { m_string3 = value; }
 
-    shared_ptr<string> Transaction::GetString4() const { return m_string4; }
-    void Transaction::SetString4(string value) { m_string4 = make_shared<string>(value); }
+    const optional<string>& Transaction::GetString4() const { return m_string4; }
+    void Transaction::SetString4(string value) { m_string4 = value; }
 
-    shared_ptr<string> Transaction::GetString5() const { return m_string5; }
-    void Transaction::SetString5(string value) { m_string5 = make_shared<string>(value); }
+    const optional<string>& Transaction::GetString5() const { return m_string5; }
+    void Transaction::SetString5(string value) { m_string5 = value; }
 
-    shared_ptr<int64_t> Transaction::GetInt1() const { return m_int1; }
-    void Transaction::SetInt1(int64_t value) { m_int1 = make_shared<int64_t>(value); }
+    const optional<int64_t>& Transaction::GetInt1() const { return m_int1; }
+    void Transaction::SetInt1(int64_t value) { m_int1 = value; }
 
-    shared_ptr<int64_t> Transaction::GetId() const { return m_id; }
-    void Transaction::SetId(int64_t value) { m_id = make_shared<int64_t>(value); }
+    const optional<int64_t>& Transaction::GetId() const { return m_id; }
+    void Transaction::SetId(int64_t value) { m_id = value; }
 
-    vector <shared_ptr<TransactionInput>>& Transaction::Inputs() { return m_inputs; }
-    vector <shared_ptr<TransactionOutput>>& Transaction::Outputs() { return m_outputs; }
-    const vector <shared_ptr<TransactionOutput>>& Transaction::OutputsConst() const { return m_outputs; }
+    vector <TransactionInput>& Transaction::Inputs() { return m_inputs; }
+    vector <TransactionOutput>& Transaction::Outputs() { return m_outputs; }
+    const vector <TransactionOutput>& Transaction::OutputsConst() const { return m_outputs; }
 
-    shared_ptr<Payload> Transaction::GetPayload() const { return m_payload; }
-    void Transaction::SetPayload(Payload value) { m_payload = make_shared<Payload>(value); }
-    bool Transaction::HasPayload() const { return m_payload != nullptr; };
+    optional<Payload>& Transaction::GetPayload() { return m_payload; }
+    const optional<Payload>& Transaction::GetPayload() const { return m_payload; }
+    void Transaction::SetPayload(Payload value) { m_payload = value; }
+    bool Transaction::HasPayload() const { return m_payload.has_value(); };
 
     string Transaction::GenerateHash(const string& data) const
     {
@@ -99,13 +101,13 @@ namespace PocketTx
 
     void Transaction::GeneratePayload()
     {
-        m_payload = make_shared<Payload>();
+        m_payload = Payload();
         m_payload->SetTxHash(*GetHash());
     }
 
     void Transaction::ClearPayload()
     {
-        m_payload = nullptr;
+        m_payload = nullopt;
     }
 
 } // namespace PocketTx

--- a/src/pocketdb/models/base/Transaction.h
+++ b/src/pocketdb/models/base/Transaction.h
@@ -16,6 +16,8 @@
 #include "pocketdb/models/base/TransactionInput.h"
 #include "pocketdb/models/base/TransactionOutput.h"
 
+#include <optional>
+
 namespace PocketTx
 {
     using namespace std;
@@ -26,7 +28,7 @@ namespace PocketTx
         Transaction();
         Transaction(const CTransactionRef& tx);
 
-        virtual shared_ptr<UniValue> Serialize() const;
+        virtual optional<UniValue> Serialize() const;
 
         virtual void Deserialize(const UniValue& src);
         virtual void DeserializeRpc(const UniValue& src);
@@ -34,51 +36,52 @@ namespace PocketTx
 
         virtual string BuildHash() = 0;
 
-        shared_ptr<string> GetHash() const;
+        const optional<string>& GetHash() const;
         void SetHash(string value);
         bool operator==(const string& hash) const;
 
-        shared_ptr<TxType> GetType() const;
+        const optional<TxType>& GetType() const;
         void SetType(TxType value);
 
-        shared_ptr<int64_t> GetTime() const;
+        const optional<int64_t>& GetTime() const;
         void SetTime(int64_t value);
 
-        shared_ptr<int64_t> GetHeight() const;
+        const optional<int64_t>& GetHeight() const;
         void SetHeight(int64_t value);
 
-        shared_ptr<string> GetBlockHash() const;
+        const optional<string>& GetBlockHash() const;
         void SetBlockHash(string value);
 
-        shared_ptr<bool> GetLast() const;
+        const optional<bool>& GetLast() const;
         void SetLast(bool value);
 
-        shared_ptr<int64_t> GetId() const;
+        const optional<int64_t>& GetId() const;
         void SetId(int64_t value);
 
-        shared_ptr<string> GetString1() const;
+        const optional<string>& GetString1() const;
         void SetString1(string value);
 
-        shared_ptr<string> GetString2() const;
+        const optional<string>& GetString2() const;
         void SetString2(string value);
 
-        shared_ptr<string> GetString3() const;
+        const optional<string>& GetString3() const;
         void SetString3(string value);
 
-        shared_ptr<string> GetString4() const;
+        const optional<string>& GetString4() const;
         void SetString4(string value);
 
-        shared_ptr<string> GetString5() const;
+        const optional<string>& GetString5() const;
         void SetString5(string value);
 
-        shared_ptr<int64_t> GetInt1() const;
+        const optional<int64_t>& GetInt1() const;
         void SetInt1(int64_t value);
 
-        vector<shared_ptr<TransactionInput>>& Inputs();
-        vector<shared_ptr<TransactionOutput>>& Outputs();
-        const vector<shared_ptr<TransactionOutput>>& OutputsConst() const;
+        vector<TransactionInput>& Inputs();
+        vector<TransactionOutput>& Outputs();
+        const vector<TransactionOutput>& OutputsConst() const;
 
-        shared_ptr<Payload> GetPayload() const;
+        optional<Payload>& GetPayload();
+        const optional<Payload>& GetPayload() const;
         void SetPayload(Payload value);
         bool HasPayload() const;
         
@@ -86,22 +89,22 @@ namespace PocketTx
         void ClearPayload();
 
     protected:
-        shared_ptr<TxType> m_type = nullptr;
-        shared_ptr<string> m_hash = nullptr;
-        shared_ptr<int64_t> m_time = nullptr;
-        shared_ptr<int64_t> m_height = nullptr;
-        shared_ptr<string> m_blockhash = nullptr;
-        shared_ptr<bool> m_last = nullptr;
-        shared_ptr<int64_t> m_id = nullptr;
-        shared_ptr<string> m_string1 = nullptr;
-        shared_ptr<string> m_string2 = nullptr;
-        shared_ptr<string> m_string3 = nullptr;
-        shared_ptr<string> m_string4 = nullptr;
-        shared_ptr<string> m_string5 = nullptr;
-        shared_ptr<int64_t> m_int1 = nullptr;
-        shared_ptr<Payload> m_payload = nullptr;
-        vector<shared_ptr<TransactionInput>> m_inputs;
-        vector<shared_ptr<TransactionOutput>> m_outputs;
+        optional<TxType> m_type = nullopt;
+        optional<string> m_hash = nullopt;
+        optional<int64_t> m_time = nullopt;
+        optional<int64_t> m_height = nullopt;
+        optional<string> m_blockhash = nullopt;
+        optional<bool> m_last = nullopt;
+        optional<int64_t> m_id = nullopt;
+        optional<string> m_string1 = nullopt;
+        optional<string> m_string2 = nullopt;
+        optional<string> m_string3 = nullopt;
+        optional<string> m_string4 = nullopt;
+        optional<string> m_string5 = nullopt;
+        optional<int64_t> m_int1 = nullopt;
+        optional<Payload> m_payload = nullopt;
+        vector<TransactionInput> m_inputs;
+        vector<TransactionOutput> m_outputs;
 
         string GenerateHash(const string& data) const;
     };

--- a/src/pocketdb/models/base/TransactionInput.cpp
+++ b/src/pocketdb/models/base/TransactionInput.cpp
@@ -6,19 +6,19 @@
 
 namespace PocketTx
 {
-    shared_ptr<string> TransactionInput::GetSpentTxHash() const { return m_spentTxHash; }
-    void TransactionInput::SetSpentTxHash(string value) { m_spentTxHash = make_shared<string>(value); }
+    const optional<string>& TransactionInput::GetSpentTxHash() const { return m_spentTxHash; }
+    void TransactionInput::SetSpentTxHash(string value) { m_spentTxHash = value; }
 
-    shared_ptr<string> TransactionInput::GetTxHash() const { return m_txHash; }
-    void TransactionInput::SetTxHash(string value) { m_txHash = make_shared<string>(value); }
+    const optional<string>& TransactionInput::GetTxHash() const { return m_txHash; }
+    void TransactionInput::SetTxHash(string value) { m_txHash = value; }
 
-    shared_ptr<int64_t> TransactionInput::GetNumber() const { return m_number; }
-    void TransactionInput::SetNumber(int64_t value) { m_number = make_shared<int64_t>(value); }
+    const optional<int64_t>& TransactionInput::GetNumber() const { return m_number; }
+    void TransactionInput::SetNumber(int64_t value) { m_number = value; }
 
-    shared_ptr<string> TransactionInput::GetAddressHash() const { return m_addresshash; }
-    void TransactionInput::SetAddressHash(string value) { m_addresshash = make_shared<string>(value); }
+    const optional<string>& TransactionInput::GetAddressHash() const { return m_addresshash; }
+    void TransactionInput::SetAddressHash(string value) { m_addresshash = value; }
 
-    shared_ptr<int64_t> TransactionInput::GetValue() const { return m_value; }
-    void TransactionInput::SetValue(int64_t value) { m_value = make_shared<int64_t>(value); }
+    const optional<int64_t>& TransactionInput::GetValue() const { return m_value; }
+    void TransactionInput::SetValue(int64_t value) { m_value = value; }
     
 } // namespace PocketTx

--- a/src/pocketdb/models/base/TransactionInput.h
+++ b/src/pocketdb/models/base/TransactionInput.h
@@ -16,27 +16,27 @@ namespace PocketTx
     public:
         TransactionInput() = default;
 
-        shared_ptr<string> GetSpentTxHash() const;
+        const optional<string>& GetSpentTxHash() const;
         void SetSpentTxHash(string value);
 
-        shared_ptr<string> GetTxHash() const;
+        const optional<string>& GetTxHash() const;
         void SetTxHash(string value);
 
-        shared_ptr<int64_t> GetNumber() const;
+        const optional<int64_t>& GetNumber() const;
         void SetNumber(int64_t value);
 
-        shared_ptr<string> GetAddressHash() const;
+        const optional<string>& GetAddressHash() const;
         void SetAddressHash(string value);
 
-        shared_ptr<int64_t> GetValue() const;
+        const optional<int64_t>& GetValue() const;
         void SetValue(int64_t value);
         
     protected:
-        shared_ptr<string> m_spentTxHash = nullptr;
-        shared_ptr<string> m_txHash = nullptr;
-        shared_ptr<int64_t> m_number = nullptr;
-        shared_ptr<string> m_addresshash = nullptr;
-        shared_ptr<int64_t> m_value = nullptr;
+        optional<string> m_spentTxHash = nullopt;
+        optional<string> m_txHash = nullopt;
+        optional<int64_t> m_number = nullopt;
+        optional<string> m_addresshash = nullopt;
+        optional<int64_t> m_value = nullopt;
     };
 
 } // namespace PocketTx

--- a/src/pocketdb/models/base/TransactionOutput.cpp
+++ b/src/pocketdb/models/base/TransactionOutput.cpp
@@ -6,25 +6,25 @@
 
 namespace PocketTx
 {
-    shared_ptr <string> TransactionOutput::GetTxHash() const { return m_txHash; }
-    void TransactionOutput::SetTxHash(string value) { m_txHash = make_shared<string>(value); }
+    const optional <string>& TransactionOutput::GetTxHash() const { return m_txHash; }
+    void TransactionOutput::SetTxHash(string value) { m_txHash = value; }
 
-    shared_ptr <int64_t> TransactionOutput::GetNumber() const { return m_number; }
-    void TransactionOutput::SetNumber(int64_t value) { m_number = make_shared<int64_t>(value); }
+    const optional <int64_t>& TransactionOutput::GetNumber() const { return m_number; }
+    void TransactionOutput::SetNumber(int64_t value) { m_number = value; }
 
-    shared_ptr <string> TransactionOutput::GetAddressHash() const { return m_addressHash; }
-    void TransactionOutput::SetAddressHash(string value) { m_addressHash = make_shared<string>(value); }
+    const optional <string>& TransactionOutput::GetAddressHash() const { return m_addressHash; }
+    void TransactionOutput::SetAddressHash(string value) { m_addressHash = value; }
 
-    shared_ptr <int64_t> TransactionOutput::GetValue() const { return m_value; }
-    void TransactionOutput::SetValue(int64_t value) { m_value = make_shared<int64_t>(value); }
+    const optional <int64_t>& TransactionOutput::GetValue() const { return m_value; }
+    void TransactionOutput::SetValue(int64_t value) { m_value = value; }
     
-    shared_ptr <string> TransactionOutput::GetScriptPubKey() const { return m_scriptPubKey; }
-    void TransactionOutput::SetScriptPubKey(string value) { m_scriptPubKey = make_shared<string>(value); }
+    const optional <string>& TransactionOutput::GetScriptPubKey() const { return m_scriptPubKey; }
+    void TransactionOutput::SetScriptPubKey(string value) { m_scriptPubKey = value; }
         
-    shared_ptr<string> TransactionOutput::GetSpentTxHash() const { return m_spentTxHash; }
-    void TransactionOutput::SetSpentTxHash(string value) { m_spentTxHash = make_shared<string>(value); }
+    const optional<string>& TransactionOutput::GetSpentTxHash() const { return m_spentTxHash; }
+    void TransactionOutput::SetSpentTxHash(string value) { m_spentTxHash = value; }
 
-    shared_ptr<int64_t> TransactionOutput::GetSpentHeight() const { return m_spentHeight; }
-    void TransactionOutput::SetSpentHeight(int64_t value) { m_spentHeight = make_shared<int64_t>(value); }
+    const optional<int64_t>& TransactionOutput::GetSpentHeight() const { return m_spentHeight; }
+    void TransactionOutput::SetSpentHeight(int64_t value) { m_spentHeight = value; }
 
 } // namespace PocketTx

--- a/src/pocketdb/models/base/TransactionOutput.h
+++ b/src/pocketdb/models/base/TransactionOutput.h
@@ -16,35 +16,35 @@ namespace PocketTx
     public:
         TransactionOutput() = default;
 
-        shared_ptr<string> GetTxHash() const;
+        const optional<string>& GetTxHash() const;
         void SetTxHash(string value);
 
-        shared_ptr<int64_t> GetNumber() const;
+        const optional<int64_t>& GetNumber() const;
         void SetNumber(int64_t value);
 
-        shared_ptr<string> GetAddressHash() const;
+        const optional<string>& GetAddressHash() const;
         void SetAddressHash(string value);
 
-        shared_ptr<int64_t> GetValue() const;
+        const optional<int64_t>& GetValue() const;
         void SetValue(int64_t value);
         
-        shared_ptr<string> GetScriptPubKey() const;
+        const optional<string>& GetScriptPubKey() const;
         void SetScriptPubKey(string value);
         
-        shared_ptr<string> GetSpentTxHash() const;
+        const optional<string>& GetSpentTxHash() const;
         void SetSpentTxHash(string value);
 
-        shared_ptr<int64_t> GetSpentHeight() const;
+        const optional<int64_t>& GetSpentHeight() const;
         void SetSpentHeight(int64_t value);
 
     protected:
-        shared_ptr<string> m_txHash = nullptr;
-        shared_ptr<int64_t> m_number = nullptr;
-        shared_ptr<string> m_addressHash = nullptr;
-        shared_ptr<int64_t> m_value = nullptr;
-        shared_ptr<string> m_scriptPubKey = nullptr;
-        shared_ptr<string> m_spentTxHash = nullptr;
-        shared_ptr<int64_t> m_spentHeight = nullptr;
+        optional<string> m_txHash = nullopt;
+        optional<int64_t> m_number = nullopt;
+        optional<string> m_addressHash = nullopt;
+        optional<int64_t> m_value = nullopt;
+        optional<string> m_scriptPubKey = nullopt;
+        optional<string> m_spentTxHash = nullopt;
+        optional<int64_t> m_spentHeight = nullopt;
     };
 
 } // namespace PocketTx

--- a/src/pocketdb/models/dto/account/Setting.cpp
+++ b/src/pocketdb/models/dto/account/Setting.cpp
@@ -18,13 +18,13 @@ namespace PocketTx
     }
 
     
-    shared_ptr <string> AccountSetting::GetAddress() const { return m_string1; }
-    void AccountSetting::SetAddress(const string& value) { m_string1 = make_shared<string>(value); }
+    const optional <string>& AccountSetting::GetAddress() const { return m_string1; }
+    void AccountSetting::SetAddress(const string& value) { m_string1 = value; }
 
-    shared_ptr <string> AccountSetting::GetPayloadData() const {return GetPayload() ? GetPayload()->GetString1() : nullptr; }
+    optional <string> AccountSetting::GetPayloadData() const {return GetPayload() ? GetPayload()->GetString1() : nullopt; }
 
 
-    shared_ptr <UniValue> AccountSetting::Serialize() const
+    optional <UniValue> AccountSetting::Serialize() const
     {
         auto result = Transaction::Serialize();
 

--- a/src/pocketdb/models/dto/account/Setting.h
+++ b/src/pocketdb/models/dto/account/Setting.h
@@ -15,16 +15,16 @@ namespace PocketTx
         AccountSetting();
         AccountSetting(const CTransactionRef& tx);
 
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
 
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;
         void DeserializePayload(const UniValue& src) override;
 
-        shared_ptr <string> GetAddress() const;
+        const optional <string>& GetAddress() const;
         void SetAddress(const string& value);
 
-        shared_ptr <string> GetPayloadData() const;
+        optional <string> GetPayloadData() const;
 
         string BuildHash() override;
 

--- a/src/pocketdb/models/dto/account/User.cpp
+++ b/src/pocketdb/models/dto/account/User.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::ACCOUNT_USER);
     }
 
-    shared_ptr <UniValue> User::Serialize() const
+    optional <UniValue> User::Serialize() const
     {
         auto result = Transaction::Serialize();
 
@@ -66,20 +66,20 @@ namespace PocketTx
         if (auto[ok, val] = TryGetStr(src, "b"); ok) m_payload->SetString7(val);
     }
 
-    shared_ptr <string> User::GetAddress() const { return m_string1; }
-    void User::SetAddress(const string& value) { m_string1 = make_shared<string>(value); }
+    const optional <string>& User::GetAddress() const { return m_string1; }
+    void User::SetAddress(const string& value) { m_string1 = value; }
 
-    shared_ptr <string> User::GetReferrerAddress() const { return m_string2; }
-    void User::SetReferrerAddress(const string& value) { m_string2 = make_shared<string>(value); }
+    const optional <string>& User::GetReferrerAddress() const { return m_string2; }
+    void User::SetReferrerAddress(const string& value) { m_string2 = value; }
 
     // Payload getters
-    shared_ptr <string> User::GetPayloadName() const { return GetPayload() ? GetPayload()->GetString2() : nullptr; }
-    shared_ptr <string> User::GetPayloadAvatar() const { return GetPayload() ? GetPayload()->GetString3() : nullptr; }
-    shared_ptr <string> User::GetPayloadUrl() const { return GetPayload() ? GetPayload()->GetString5() : nullptr; }
-    shared_ptr <string> User::GetPayloadLang() const { return GetPayload() ? GetPayload()->GetString1() : nullptr; }
-    shared_ptr <string> User::GetPayloadAbout() const { return GetPayload() ? GetPayload()->GetString4() : nullptr; }
-    shared_ptr <string> User::GetPayloadDonations() const { return GetPayload() ? GetPayload()->GetString7() : nullptr; }
-    shared_ptr <string> User::GetPayloadPubkey() const { return GetPayload() ? GetPayload()->GetString6() : nullptr; }
+    optional <string> User::GetPayloadName() const { return GetPayload() ? GetPayload()->GetString2() : nullopt; }
+    optional <string> User::GetPayloadAvatar() const { return GetPayload() ? GetPayload()->GetString3() : nullopt; }
+    optional <string> User::GetPayloadUrl() const { return GetPayload() ? GetPayload()->GetString5() : nullopt; }
+    optional <string> User::GetPayloadLang() const { return GetPayload() ? GetPayload()->GetString1() : nullopt; }
+    optional <string> User::GetPayloadAbout() const { return GetPayload() ? GetPayload()->GetString4() : nullopt; }
+    optional <string> User::GetPayloadDonations() const { return GetPayload() ? GetPayload()->GetString7() : nullopt; }
+    optional <string> User::GetPayloadPubkey() const { return GetPayload() ? GetPayload()->GetString6() : nullopt; }
 
     void User::DeserializePayload(const UniValue& src)
     {

--- a/src/pocketdb/models/dto/account/User.h
+++ b/src/pocketdb/models/dto/account/User.h
@@ -15,26 +15,26 @@ namespace PocketTx
         User();
         User(const std::shared_ptr<const CTransaction>& tx);
 
-        shared_ptr <UniValue> Serialize() const override;
+        optional <UniValue> Serialize() const override;
 
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;
         void DeserializePayload(const UniValue& src) override;
 
-        shared_ptr <string> GetAddress() const;
+        const optional <string>& GetAddress() const;
         void SetAddress(const string& value);
 
-        shared_ptr <string> GetReferrerAddress() const;
+        const optional <string>& GetReferrerAddress() const;
         void SetReferrerAddress(const string& value);
 
         // Payload getters
-        shared_ptr <string> GetPayloadName() const;
-        shared_ptr <string> GetPayloadAvatar() const;
-        shared_ptr <string> GetPayloadUrl() const;
-        shared_ptr <string> GetPayloadLang() const;
-        shared_ptr <string> GetPayloadAbout() const;
-        shared_ptr <string> GetPayloadDonations() const;
-        shared_ptr <string> GetPayloadPubkey() const;
+        optional <string> GetPayloadName() const;
+        optional <string> GetPayloadAvatar() const;
+        optional <string> GetPayloadUrl() const;
+        optional <string> GetPayloadLang() const;
+        optional <string> GetPayloadAbout() const;
+        optional <string> GetPayloadDonations() const;
+        optional <string> GetPayloadPubkey() const;
 
         string BuildHash() override;
         string BuildHash(bool includeReferrer);

--- a/src/pocketdb/models/dto/action/Blocking.cpp
+++ b/src/pocketdb/models/dto/action/Blocking.cpp
@@ -18,7 +18,7 @@ namespace PocketTx
         SetType(TxType::ACTION_BLOCKING);
     }
 
-    shared_ptr <UniValue> Blocking::Serialize() const
+    optional <UniValue> Blocking::Serialize() const
     {
         auto result = Transaction::Serialize();
 
@@ -44,13 +44,13 @@ namespace PocketTx
         if (auto[ok, val] = TryGetStr(src, "addresses"); ok) SetAddressesTo(val);
     }
 
-    shared_ptr <string> Blocking::GetAddress() const { return m_string1; }
-    void Blocking::SetAddress(const string& value) { m_string1 = make_shared<string>(value); }
+    const optional <string>& Blocking::GetAddress() const { return m_string1; }
+    void Blocking::SetAddress(const string& value) { m_string1 = value; }
 
-    shared_ptr <string> Blocking::GetAddressTo() const { return m_string2; }
-    shared_ptr <string> Blocking::GetAddressesTo() const { return m_string3; }
-    void Blocking::SetAddressTo(const string& value) { m_string2 = make_shared<string>(value); }
-    void Blocking::SetAddressesTo(const string& value) { m_string3 = make_shared<string>(value); }
+    const optional <string>& Blocking::GetAddressTo() const { return m_string2; }
+    const optional <string>& Blocking::GetAddressesTo() const { return m_string3; }
+    void Blocking::SetAddressTo(const string& value) { m_string2 = value; }
+    void Blocking::SetAddressesTo(const string& value) { m_string3 = value; }
 
     void Blocking::DeserializePayload(const UniValue& src)
     {

--- a/src/pocketdb/models/dto/action/Blocking.h
+++ b/src/pocketdb/models/dto/action/Blocking.h
@@ -16,19 +16,19 @@ namespace PocketTx
         Blocking();
         Blocking(const std::shared_ptr<const CTransaction>& tx);
 
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
 
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;
         void DeserializePayload(const UniValue& src) override;
 
-        shared_ptr<string> GetAddress() const;
+        const optional <string>& GetAddress() const;
         void SetAddress(const string& value);
 
-        shared_ptr<string> GetAddressTo() const;
+        const optional <string>& GetAddressTo() const;
         void SetAddressTo(const string& value);
 
-        shared_ptr<string> GetAddressesTo() const;
+        const optional <string>& GetAddressesTo() const;
         void SetAddressesTo(const string& value);
 
         string BuildHash() override;

--- a/src/pocketdb/models/dto/action/BlockingCancel.cpp
+++ b/src/pocketdb/models/dto/action/BlockingCancel.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::ACTION_BLOCKING_CANCEL);
     }
 
-    shared_ptr <UniValue> BlockingCancel::Serialize() const
+    optional <UniValue> BlockingCancel::Serialize() const
     {
         auto result = Blocking::Serialize();
 

--- a/src/pocketdb/models/dto/action/BlockingCancel.h
+++ b/src/pocketdb/models/dto/action/BlockingCancel.h
@@ -16,7 +16,7 @@ namespace PocketTx
         BlockingCancel();
         BlockingCancel(const std::shared_ptr<const CTransaction>& tx);
 
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
     };
 
 } // namespace PocketTx

--- a/src/pocketdb/models/dto/action/BoostContent.cpp
+++ b/src/pocketdb/models/dto/action/BoostContent.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::BOOST_CONTENT);
     }
 
-    shared_ptr <UniValue> BoostContent::Serialize() const
+    optional <UniValue> BoostContent::Serialize() const
     {
         auto result = Transaction::Serialize();
 
@@ -45,11 +45,11 @@ namespace PocketTx
     }
     
 
-    shared_ptr <string> BoostContent::GetAddress() const { return m_string1; }
-    void BoostContent::SetAddress(const string& value) { m_string1 = make_shared<string>(value); }
+    const optional <string>& BoostContent::GetAddress() const { return m_string1; }
+    void BoostContent::SetAddress(const string& value) { m_string1 = value; }
 
-    shared_ptr <string> BoostContent::GetContentTxHash() const { return m_string2; }
-    void BoostContent::SetContentTxHash(const string& value) { m_string2 = make_shared<string>(value); }
+    const optional <string>& BoostContent::GetContentTxHash() const { return m_string2; }
+    void BoostContent::SetContentTxHash(const string& value) { m_string2 = value; }
 
 
     string BoostContent::BuildHash()

--- a/src/pocketdb/models/dto/action/BoostContent.h
+++ b/src/pocketdb/models/dto/action/BoostContent.h
@@ -16,16 +16,16 @@ namespace PocketTx
         BoostContent();
         BoostContent(const std::shared_ptr<const CTransaction>& tx);
 
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
 
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;
         void DeserializePayload(const UniValue& src) override;
 
-        shared_ptr <string> GetAddress() const;
+        const optional <string>& GetAddress() const;
         void SetAddress(const string& value);
 
-        shared_ptr<string> GetContentTxHash() const;
+        const optional <string>& GetContentTxHash() const;
         void SetContentTxHash(const string& value);
 
         string BuildHash() override;

--- a/src/pocketdb/models/dto/action/Complain.cpp
+++ b/src/pocketdb/models/dto/action/Complain.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::ACTION_COMPLAIN);
     }
 
-    shared_ptr <UniValue> Complain::Serialize() const
+    optional <UniValue> Complain::Serialize() const
     {
         auto result = Transaction::Serialize();
 
@@ -42,14 +42,14 @@ namespace PocketTx
         if (auto[ok, val] = TryGetInt64(src, "reason"); ok) SetReason(val);
     }
 
-    shared_ptr <string> Complain::GetAddress() const { return m_string1; }
-    void Complain::SetAddress(const string& value) { m_string1 = make_shared<string>(value); }
+    const optional <string>& Complain::GetAddress() const { return m_string1; }
+    void Complain::SetAddress(const string& value) { m_string1 = value; }
 
-    shared_ptr <string> Complain::GetPostTxHash() const { return m_string2; }
-    void Complain::SetPostTxHash(const string& value) { m_string2 = make_shared<string>(value); }
+    const optional <string>& Complain::GetPostTxHash() const { return m_string2; }
+    void Complain::SetPostTxHash(const string& value) { m_string2 = value; }
 
-    shared_ptr <int64_t> Complain::GetReason() const { return m_int1; }
-    void Complain::SetReason(int64_t value) { m_int1 = make_shared<int64_t>(value); }
+    const optional <int64_t>& Complain::GetReason() const { return m_int1; }
+    void Complain::SetReason(int64_t value) { m_int1 = value; }
 
     void Complain::DeserializePayload(const UniValue& src)
     {

--- a/src/pocketdb/models/dto/action/Complain.h
+++ b/src/pocketdb/models/dto/action/Complain.h
@@ -16,19 +16,19 @@ namespace PocketTx
         Complain();
         Complain(const std::shared_ptr<const CTransaction>& tx);
 
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
 
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;
         void DeserializePayload(const UniValue& src) override;
 
-        shared_ptr<string> GetAddress() const;
+        const optional<string>& GetAddress() const;
         void SetAddress(const string& value);
 
-        shared_ptr<string> GetPostTxHash() const;
+        const optional<string>& GetPostTxHash() const;
         void SetPostTxHash(const string& value);
 
-        shared_ptr <int64_t> GetReason() const;
+        const optional <int64_t>& GetReason() const;
         void SetReason(int64_t value);
 
         string BuildHash() override;

--- a/src/pocketdb/models/dto/action/ScoreComment.cpp
+++ b/src/pocketdb/models/dto/action/ScoreComment.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::ACTION_SCORE_COMMENT);
     }
 
-    shared_ptr <UniValue> ScoreComment::Serialize() const
+    optional <UniValue> ScoreComment::Serialize() const
     {
         auto result = Transaction::Serialize();
 
@@ -42,14 +42,14 @@ namespace PocketTx
         if (auto[ok, val] = TryGetInt64(src, "value"); ok) SetValue(val);
     }
 
-    shared_ptr <string> ScoreComment::GetAddress() const { return m_string1; }
-    void ScoreComment::SetAddress(const string& value) { m_string1 = make_shared<string>(value); }
+    const optional <string>& ScoreComment::GetAddress() const { return m_string1; }
+    void ScoreComment::SetAddress(const string& value) { m_string1 = value; }
 
-    shared_ptr <string> ScoreComment::GetCommentTxHash() const { return m_string2; }
-    void ScoreComment::SetCommentTxHash(const string& value) { m_string2 = make_shared<string>(value); }
+    const optional <string>& ScoreComment::GetCommentTxHash() const { return m_string2; }
+    void ScoreComment::SetCommentTxHash(const string& value) { m_string2 = value; }
 
-    shared_ptr <int64_t> ScoreComment::GetValue() const { return m_int1; }
-    void ScoreComment::SetValue(int64_t value) { m_int1 = make_shared<int64_t>(value); }
+    const optional <int64_t>& ScoreComment::GetValue() const { return m_int1; }
+    void ScoreComment::SetValue(int64_t value) { m_int1 = value; }
 
     void ScoreComment::DeserializePayload(const UniValue& src)
     {

--- a/src/pocketdb/models/dto/action/ScoreComment.h
+++ b/src/pocketdb/models/dto/action/ScoreComment.h
@@ -16,19 +16,19 @@ namespace PocketTx
         ScoreComment();
         ScoreComment(const std::shared_ptr<const CTransaction>& tx);
 
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
 
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;
         void DeserializePayload(const UniValue& src) override;
 
-        shared_ptr <string> GetAddress() const;
+        const optional <string>& GetAddress() const;
         void SetAddress(const string& value);
 
-        shared_ptr <string> GetCommentTxHash() const;
+        const optional <string>& GetCommentTxHash() const;
         void SetCommentTxHash(const string& value);
 
-        shared_ptr <int64_t> GetValue() const;
+        const optional <int64_t>& GetValue() const;
         void SetValue(int64_t value);
 
         string BuildHash() override;

--- a/src/pocketdb/models/dto/action/ScoreContent.cpp
+++ b/src/pocketdb/models/dto/action/ScoreContent.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::ACTION_SCORE_CONTENT);
     }
 
-    shared_ptr <UniValue> ScoreContent::Serialize() const
+    optional <UniValue> ScoreContent::Serialize() const
     {
         auto result = Transaction::Serialize();
 
@@ -42,14 +42,14 @@ namespace PocketTx
         if (auto[ok, val] = TryGetInt64(src, "value"); ok) SetValue(val);
     }
 
-    shared_ptr <string> ScoreContent::GetAddress() const { return m_string1; }
-    void ScoreContent::SetAddress(const string& value) { m_string1 = make_shared<string>(value); }
+    const optional <string>& ScoreContent::GetAddress() const { return m_string1; }
+    void ScoreContent::SetAddress(const string& value) { m_string1 = value; }
 
-    shared_ptr <string> ScoreContent::GetContentTxHash() const { return m_string2; }
-    void ScoreContent::SetContentTxHash(const string& value) { m_string2 = make_shared<string>(value); }
+    const optional <string>& ScoreContent::GetContentTxHash() const { return m_string2; }
+    void ScoreContent::SetContentTxHash(const string& value) { m_string2 = value; }
 
-    shared_ptr <int64_t> ScoreContent::GetValue() const { return m_int1; }
-    void ScoreContent::SetValue(int64_t value) { m_int1 = make_shared<int64_t>(value); }
+    const optional <int64_t>& ScoreContent::GetValue() const { return m_int1; }
+    void ScoreContent::SetValue(int64_t value) { m_int1 = value; }
 
     void ScoreContent::DeserializePayload(const UniValue& src)
     {

--- a/src/pocketdb/models/dto/action/ScoreContent.h
+++ b/src/pocketdb/models/dto/action/ScoreContent.h
@@ -16,19 +16,19 @@ namespace PocketTx
         ScoreContent();
         ScoreContent(const std::shared_ptr<const CTransaction>& tx);
 
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
 
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;
         void DeserializePayload(const UniValue& src) override;
 
-        shared_ptr <string> GetAddress() const;
+        const optional <string>& GetAddress() const;
         void SetAddress(const string& value);
 
-        shared_ptr<string> GetContentTxHash() const;
+        const optional<string>& GetContentTxHash() const;
         void SetContentTxHash(const string& value);
 
-        shared_ptr<int64_t> GetValue() const;
+        const optional<int64_t>& GetValue() const;
         void SetValue(int64_t value);
 
         string BuildHash() override;

--- a/src/pocketdb/models/dto/action/Subscribe.cpp
+++ b/src/pocketdb/models/dto/action/Subscribe.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::ACTION_SUBSCRIBE);
     }
 
-    shared_ptr <UniValue> Subscribe::Serialize() const
+    optional <UniValue> Subscribe::Serialize() const
     {
         auto result = Transaction::Serialize();
 
@@ -41,11 +41,11 @@ namespace PocketTx
         if (auto[ok, val] = TryGetStr(src, "address"); ok) SetAddressTo(val);
     }
 
-    shared_ptr <string> Subscribe::GetAddress() const { return m_string1; }
-    void Subscribe::SetAddress(const string& value) { m_string1 = make_shared<string>(value); }
+    const optional <string>& Subscribe::GetAddress() const { return m_string1; }
+    void Subscribe::SetAddress(const string& value) { m_string1 = value; }
 
-    shared_ptr <string> Subscribe::GetAddressTo() const { return m_string2; }
-    void Subscribe::SetAddressTo(const string& value) { m_string2 = make_shared<string>(value); }
+    const optional <string>& Subscribe::GetAddressTo() const { return m_string2; }
+    void Subscribe::SetAddressTo(const string& value) { m_string2 = value; }
 
     void Subscribe::DeserializePayload(const UniValue& src)
     {

--- a/src/pocketdb/models/dto/action/Subscribe.h
+++ b/src/pocketdb/models/dto/action/Subscribe.h
@@ -16,16 +16,16 @@ namespace PocketTx
         Subscribe();
         Subscribe(const std::shared_ptr<const CTransaction>& tx);
 
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
 
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;
         void DeserializePayload(const UniValue& src) override;
 
-        shared_ptr <string> GetAddress() const;
+        const optional <string>& GetAddress() const;
         void SetAddress(const string& value);
 
-        shared_ptr <string> GetAddressTo() const;
+        const optional <string>& GetAddressTo() const;
         void SetAddressTo(const string& value);
 
         string BuildHash() override;

--- a/src/pocketdb/models/dto/action/SubscribeCancel.cpp
+++ b/src/pocketdb/models/dto/action/SubscribeCancel.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::ACTION_SUBSCRIBE_CANCEL);
     }
 
-    shared_ptr <UniValue> SubscribeCancel::Serialize() const
+    optional <UniValue> SubscribeCancel::Serialize() const
     {
         auto result = Subscribe::Serialize();
         result->pushKV("unsubscribe", true);

--- a/src/pocketdb/models/dto/action/SubscribeCancel.h
+++ b/src/pocketdb/models/dto/action/SubscribeCancel.h
@@ -14,7 +14,7 @@ namespace PocketTx
     public:
         SubscribeCancel();
         SubscribeCancel(const std::shared_ptr<const CTransaction>& tx);
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
     };
 
 } // namespace PocketTx

--- a/src/pocketdb/models/dto/action/SubscribePrivate.cpp
+++ b/src/pocketdb/models/dto/action/SubscribePrivate.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::ACTION_SUBSCRIBE_PRIVATE);
     }
 
-    shared_ptr <UniValue> SubscribePrivate::Serialize() const
+    optional <UniValue> SubscribePrivate::Serialize() const
     {
         auto result = Subscribe::Serialize();
 

--- a/src/pocketdb/models/dto/action/SubscribePrivate.h
+++ b/src/pocketdb/models/dto/action/SubscribePrivate.h
@@ -14,7 +14,7 @@ namespace PocketTx
     public:
         SubscribePrivate();
         SubscribePrivate(const std::shared_ptr<const CTransaction>& tx);
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
     };
 
 } // namespace PocketTx

--- a/src/pocketdb/models/dto/content/Comment.cpp
+++ b/src/pocketdb/models/dto/content/Comment.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::CONTENT_COMMENT);
     }
 
-    shared_ptr <UniValue> Comment::Serialize() const
+    optional <UniValue> Comment::Serialize() const
     {
         auto result = Transaction::Serialize();
 
@@ -64,22 +64,22 @@ namespace PocketTx
         if (auto[ok, val] = TryGetStr(src, "msg"); ok) SetPayloadMsg(val);
     }
 
-    shared_ptr <string> Comment::GetAddress() const { return m_string1; }
-    void Comment::SetAddress(const string& value) { m_string1 = make_shared<string>(value); }
+    const optional <string>& Comment::GetAddress() const { return m_string1; }
+    void Comment::SetAddress(const string& value) { m_string1 = value; }
 
-    shared_ptr <string> Comment::GetRootTxHash() const { return m_string2; }
-    void Comment::SetRootTxHash(const string& value) { m_string2 = make_shared<string>(value); }
+    const optional <string>& Comment::GetRootTxHash() const { return m_string2; }
+    void Comment::SetRootTxHash(const string& value) { m_string2 = value; }
 
-    shared_ptr <string> Comment::GetPostTxHash() const { return m_string3; }
-    void Comment::SetPostTxHash(const string& value) { m_string3 = make_shared<string>(value); }
+    const optional <string>& Comment::GetPostTxHash() const { return m_string3; }
+    void Comment::SetPostTxHash(const string& value) { m_string3 = value; }
 
-    shared_ptr <string> Comment::GetParentTxHash() const { return m_string4; }
-    void Comment::SetParentTxHash(const string& value) { m_string4 = make_shared<string>(value); }
+    const optional <string>& Comment::GetParentTxHash() const { return m_string4; }
+    void Comment::SetParentTxHash(const string& value) { m_string4 = value; }
 
-    shared_ptr <string> Comment::GetAnswerTxHash() const { return m_string5; }
-    void Comment::SetAnswerTxHash(const string& value) { m_string5 = make_shared<string>(value); }
+    const optional <string>& Comment::GetAnswerTxHash() const { return m_string5; }
+    void Comment::SetAnswerTxHash(const string& value) { m_string5 = value; }
 
-    shared_ptr <string> Comment::GetPayloadMsg() const { return Transaction::GetPayload()->GetString1(); }
+    const optional <string>& Comment::GetPayloadMsg() const { return Transaction::GetPayload()->GetString1(); }
     void Comment::SetPayloadMsg(const string& value) { Transaction::GetPayload()->SetString1(value); }
 
     void Comment::DeserializePayload(const UniValue& src)

--- a/src/pocketdb/models/dto/content/Comment.h
+++ b/src/pocketdb/models/dto/content/Comment.h
@@ -15,29 +15,29 @@ namespace PocketTx
         Comment();
         Comment(const std::shared_ptr<const CTransaction>& tx);
 
-        shared_ptr <UniValue> Serialize() const override;
+        optional <UniValue> Serialize() const override;
 
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;
         void DeserializePayload(const UniValue& src) override;
 
-        shared_ptr <string> GetAddress() const;
+        const optional <string>& GetAddress() const;
         void SetAddress(const string& value);
 
-        shared_ptr <string> GetRootTxHash() const;
+        const optional <string>& GetRootTxHash() const;
         void SetRootTxHash(const string& value);
 
-        shared_ptr <string> GetPostTxHash() const;
+        const optional <string>& GetPostTxHash() const;
         void SetPostTxHash(const string& value);
 
-        shared_ptr <string> GetParentTxHash() const;
+        const optional <string>& GetParentTxHash() const;
         void SetParentTxHash(const string& value);
 
-        shared_ptr <string> GetAnswerTxHash() const;
+        const optional <string>& GetAnswerTxHash() const;
         void SetAnswerTxHash(const string& value);
 
         // Payload getters
-        shared_ptr <string> GetPayloadMsg() const;
+        const optional <string>& GetPayloadMsg() const;
         void SetPayloadMsg(const string& value);
 
         string BuildHash() override;

--- a/src/pocketdb/models/dto/content/Content.cpp
+++ b/src/pocketdb/models/dto/content/Content.cpp
@@ -15,12 +15,12 @@ namespace PocketTx
     {
     }
 
-    shared_ptr<string> Content::GetAddress() const { return m_string1; }
-    void Content::SetAddress(const string& value) { m_string1 = make_shared<string>(value); }
+    const optional<string>& Content::GetAddress() const { return m_string1; }
+    void Content::SetAddress(const string& value) { m_string1 = value; }
 
-    shared_ptr<string> Content::GetRootTxHash() const { return m_string2; }
-    void Content::SetRootTxHash(const string& value) { m_string2 = make_shared<string>(value); }
+    const optional<string>& Content::GetRootTxHash() const { return m_string2; }
+    void Content::SetRootTxHash(const string& value) { m_string2 = value; }
 
-    bool Content::IsEdit() const { return *m_string2 != *m_hash; }
+    bool Content::IsEdit() const { return m_string2 != m_hash; }
 
 } // namespace PocketTx

--- a/src/pocketdb/models/dto/content/Content.h
+++ b/src/pocketdb/models/dto/content/Content.h
@@ -17,10 +17,10 @@ namespace PocketTx
         Content();
         Content(const CTransactionRef& tx);
 
-        shared_ptr<string> GetAddress() const;
+        const optional<string>& GetAddress() const;
         void SetAddress(const string& value);
 
-        shared_ptr<string> GetRootTxHash() const;
+        const optional<string>& GetRootTxHash() const;
         void SetRootTxHash(const string& value);
         
         bool IsEdit() const;

--- a/src/pocketdb/models/dto/content/ContentDelete.cpp
+++ b/src/pocketdb/models/dto/content/ContentDelete.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::CONTENT_DELETE);
     }
 
-    shared_ptr <UniValue> ContentDelete::Serialize() const
+    optional <UniValue> ContentDelete::Serialize() const
     {
         auto result = Transaction::Serialize();
 

--- a/src/pocketdb/models/dto/content/ContentDelete.h
+++ b/src/pocketdb/models/dto/content/ContentDelete.h
@@ -17,7 +17,7 @@ namespace PocketTx
         ContentDelete();
         ContentDelete(const CTransactionRef& tx);
 
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
 
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;

--- a/src/pocketdb/models/dto/content/Post.cpp
+++ b/src/pocketdb/models/dto/content/Post.cpp
@@ -17,7 +17,7 @@ namespace PocketTx
         SetType(TxType::CONTENT_POST);
     }
 
-    shared_ptr<UniValue> Post::Serialize() const
+    optional<UniValue> Post::Serialize() const
     {
         auto result = Content::Serialize();
 
@@ -101,16 +101,16 @@ namespace PocketTx
         if (auto[ok, val] = TryGetStr(src, "settings"); ok) m_payload->SetString6(val);
     }
     
-    shared_ptr<string> Post::GetRelayTxHash() const { return m_string3; }
-    void Post::SetRelayTxHash(const string& value) { m_string3 = make_shared<string>(value); }
+    const optional<string>& Post::GetRelayTxHash() const { return m_string3; }
+    void Post::SetRelayTxHash(const string& value) { m_string3 = value; }
 
-    shared_ptr<string> Post::GetPayloadLang() const { return GetPayload() ? GetPayload()->GetString1() : nullptr; }
-    shared_ptr<string> Post::GetPayloadCaption() const { return GetPayload() ? GetPayload()->GetString2() : nullptr; }
-    shared_ptr<string> Post::GetPayloadMessage() const { return GetPayload() ? GetPayload()->GetString3() : nullptr; }
-    shared_ptr<string> Post::GetPayloadTags() const { return GetPayload() ? GetPayload()->GetString4() : nullptr; }
-    shared_ptr<string> Post::GetPayloadUrl() const { return GetPayload() ? GetPayload()->GetString7() : nullptr; }
-    shared_ptr<string> Post::GetPayloadImages() const { return GetPayload() ? GetPayload()->GetString5() : nullptr; }
-    shared_ptr<string> Post::GetPayloadSettings() const { return GetPayload() ? GetPayload()->GetString6() : nullptr; }
+    optional<string> Post::GetPayloadLang() const { return GetPayload() ? GetPayload()->GetString1() : nullopt; }
+    optional<string> Post::GetPayloadCaption() const { return GetPayload() ? GetPayload()->GetString2() : nullopt; }
+    optional<string> Post::GetPayloadMessage() const { return GetPayload() ? GetPayload()->GetString3() : nullopt; }
+    optional<string> Post::GetPayloadTags() const { return GetPayload() ? GetPayload()->GetString4() : nullopt; }
+    optional<string> Post::GetPayloadUrl() const { return GetPayload() ? GetPayload()->GetString7() : nullopt; }
+    optional<string> Post::GetPayloadImages() const { return GetPayload() ? GetPayload()->GetString5() : nullopt; }
+    optional<string> Post::GetPayloadSettings() const { return GetPayload() ? GetPayload()->GetString6() : nullopt; }
 
     string Post::BuildHash()
     {

--- a/src/pocketdb/models/dto/content/Post.h
+++ b/src/pocketdb/models/dto/content/Post.h
@@ -17,21 +17,23 @@ namespace PocketTx
         Post();
         Post(const CTransactionRef& tx);
 
-        shared_ptr<UniValue> Serialize() const override;
+        optional<UniValue> Serialize() const override;
         void Deserialize(const UniValue& src) override;
         void DeserializeRpc(const UniValue& src) override;
         void DeserializePayload(const UniValue& src) override;
 
-        shared_ptr<string> GetRelayTxHash() const;
+        const optional<string>& GetRelayTxHash() const;
         void SetRelayTxHash(const string& value);
 
-        shared_ptr<string> GetPayloadLang() const;
-        shared_ptr<string> GetPayloadCaption() const;
-        shared_ptr<string> GetPayloadMessage() const;
-        shared_ptr<string> GetPayloadTags() const;
-        shared_ptr<string> GetPayloadUrl() const;
-        shared_ptr<string> GetPayloadImages() const;
-        shared_ptr<string> GetPayloadSettings() const;
+        // TODO (losty): not const& because requires a temporarily object creation
+        //in case of null payload
+        optional<string> GetPayloadLang() const;
+        optional<string> GetPayloadCaption() const;
+        optional<string> GetPayloadMessage() const;
+        optional<string> GetPayloadTags() const;
+        optional<string> GetPayloadUrl() const;
+        optional<string> GetPayloadImages() const;
+        optional<string> GetPayloadSettings() const;
 
         string BuildHash() override;
     };

--- a/src/pocketdb/models/dto/moderation/Flag.cpp
+++ b/src/pocketdb/models/dto/moderation/Flag.cpp
@@ -28,14 +28,14 @@ namespace PocketTx
     }
 
     
-    shared_ptr<string> ModerationFlag::GetContentTxHash() const { return m_string2; }
-    void ModerationFlag::SetContentTxHash(const string& value) { m_string2 = make_shared<string>(value); }
+    const optional<string>& ModerationFlag::GetContentTxHash() const { return m_string2; }
+    void ModerationFlag::SetContentTxHash(const string& value) { m_string2 = value; }
     
-    shared_ptr<string> ModerationFlag::GetContentAddressHash() const { return m_string3; }
-    void ModerationFlag::SetContentAddressHash(const string& value) { m_string3 = make_shared<string>(value); }
+    const optional<string>& ModerationFlag::GetContentAddressHash() const { return m_string3; }
+    void ModerationFlag::SetContentAddressHash(const string& value) { m_string3 = value; }
     
-    shared_ptr<int64_t> ModerationFlag::GetReason() const { return m_int1; }
-    void ModerationFlag::SetReason(int64_t value) { m_int1 = make_shared<int64_t>(value); }
+    const optional<int64_t>& ModerationFlag::GetReason() const { return m_int1; }
+    void ModerationFlag::SetReason(int64_t value) { m_int1 = value; }
 
 
 } // namespace PocketTx

--- a/src/pocketdb/models/dto/moderation/Flag.h
+++ b/src/pocketdb/models/dto/moderation/Flag.h
@@ -17,13 +17,13 @@ namespace PocketTx
 
         string BuildHash() override;
 
-        shared_ptr<string> GetContentTxHash() const;
+        const optional<string>& GetContentTxHash() const;
         void SetContentTxHash(const string& value);
         
-        shared_ptr<string> GetContentAddressHash() const;
+        const optional<string>& GetContentAddressHash() const;
         void SetContentAddressHash(const string& value);
 
-        shared_ptr<int64_t> GetReason() const;
+        const optional<int64_t>& GetReason() const;
         void SetReason(int64_t value);
 
     }; // class ModerationFlag

--- a/src/pocketdb/repositories/BaseRepository.h
+++ b/src/pocketdb/repositories/BaseRepository.h
@@ -159,7 +159,9 @@ namespace PocketDb
         // BINDS
         // --------------------------------
 
-        bool TryBindStatementText(shared_ptr<sqlite3_stmt*>& stmt, int index, shared_ptr<std::string> value)
+        // TODO (losty): "value" is being passed by rvalue reference because this will force it to not accept passing here temporarily created objects
+        // that will be destroyed right after this function call and thus result in corrupted database because of SQLITE_STATIC that forcec sqlite to not accuire memory itself.
+        bool TryBindStatementText(shared_ptr<sqlite3_stmt*>& stmt, int index, optional<std::string>& value)
         {
             if (!value) return true;
 
@@ -178,7 +180,7 @@ namespace PocketDb
                     __func__, index, value));
         }
 
-        bool TryBindStatementInt(shared_ptr<sqlite3_stmt*>& stmt, int index, const shared_ptr<int>& value)
+        bool TryBindStatementInt(shared_ptr<sqlite3_stmt*>& stmt, int index, const optional<int>& value)
         {
             if (!value) return true;
 
@@ -194,7 +196,7 @@ namespace PocketDb
                     __func__, index, value));
         }
 
-        bool TryBindStatementInt64(shared_ptr<sqlite3_stmt*>& stmt, int index, const shared_ptr<int64_t>& value)
+        bool TryBindStatementInt64(shared_ptr<sqlite3_stmt*>& stmt, int index, const optional<int64_t>& value)
         {
             if (!value) return true;
 

--- a/src/pocketdb/repositories/TransactionRepository.cpp
+++ b/src/pocketdb/repositories/TransactionRepository.cpp
@@ -132,17 +132,17 @@ namespace PocketDb
         {
             bool incomplete = false;
 
-            PTransactionInputRef input = make_shared<TransactionInput>();
-            input->SetSpentTxHash(txHash);
+            TransactionInput input;
+            input.SetSpentTxHash(txHash);
 
-            if (auto[ok, value] = TryGetColumnString(stmt, 4); ok) input->SetTxHash(value);
+            if (auto[ok, value] = TryGetColumnString(stmt, 4); ok) input.SetTxHash(value);
             else incomplete = true;
 
-            if (auto[ok, value] = TryGetColumnInt64(stmt, 5); ok) input->SetNumber(value);
+            if (auto[ok, value] = TryGetColumnInt64(stmt, 5); ok) input.SetNumber(value);
             else incomplete = true;
 
-            if (auto[ok, value] = TryGetColumnInt64(stmt, 6); ok) input->SetValue(value);
-            if (auto[ok, value] = TryGetColumnString(stmt, 8); ok) input->SetAddressHash(value);
+            if (auto[ok, value] = TryGetColumnInt64(stmt, 6); ok) input.SetValue(value);
+            if (auto[ok, value] = TryGetColumnString(stmt, 8); ok) input.SetAddressHash(value);
 
             ptx->Inputs().push_back(input);
             return !incomplete;
@@ -157,23 +157,23 @@ namespace PocketDb
         {
             bool incomplete = false;
 
-            PTransactionOutputRef output = make_shared<TransactionOutput>();
-            output->SetTxHash(txHash);
+            TransactionOutput output;
+            output.SetTxHash(txHash);
 
-            if (auto[ok, value] = TryGetColumnInt64(stmt, 3); ok) output->SetNumber(value);
+            if (auto[ok, value] = TryGetColumnInt64(stmt, 3); ok) output.SetNumber(value);
             else incomplete = true;
 
-            if (auto[ok, value] = TryGetColumnString(stmt, 4); ok) output->SetAddressHash(value);
+            if (auto[ok, value] = TryGetColumnString(stmt, 4); ok) output.SetAddressHash(value);
             else incomplete = true;
 
-            if (auto[ok, value] = TryGetColumnInt64(stmt, 5); ok) output->SetValue(value);
+            if (auto[ok, value] = TryGetColumnInt64(stmt, 5); ok) output.SetValue(value);
             else incomplete = true;
 
-            if (auto[ok, value] = TryGetColumnString(stmt, 10); ok) output->SetScriptPubKey(value);
+            if (auto[ok, value] = TryGetColumnString(stmt, 10); ok) output.SetScriptPubKey(value);
             else incomplete = true;
 
-            if (auto[ok, value] = TryGetColumnString(stmt, 14); ok) output->SetSpentTxHash(value);
-            if (auto[ok, value] = TryGetColumnInt64(stmt, 15); ok) output->SetSpentHeight(value);
+            if (auto[ok, value] = TryGetColumnString(stmt, 14); ok) output.SetSpentTxHash(value);
+            if (auto[ok, value] = TryGetColumnInt64(stmt, 15); ok) output.SetSpentHeight(value);
 
             ptx->Outputs().push_back(output);
             return !incomplete;
@@ -513,9 +513,9 @@ namespace PocketDb
                 )
             )sql");
 
-            TryBindStatementText(stmt, 1, input->GetSpentTxHash());
-            TryBindStatementText(stmt, 2, input->GetTxHash());
-            TryBindStatementInt64(stmt, 3, input->GetNumber());
+            TryBindStatementText(stmt, 1, input.GetSpentTxHash());
+            TryBindStatementText(stmt, 2, input.GetTxHash());
+            TryBindStatementInt64(stmt, 3, input.GetNumber());
 
             TryStepStatement(stmt);
         }
@@ -544,11 +544,11 @@ namespace PocketDb
                 )
             )sql");
 
-            TryBindStatementText(stmt, 1, output->GetTxHash());
-            TryBindStatementInt64(stmt, 2, output->GetNumber());
-            TryBindStatementText(stmt, 3, output->GetAddressHash());
-            TryBindStatementInt64(stmt, 4, output->GetValue());
-            TryBindStatementText(stmt, 5, output->GetScriptPubKey());
+            TryBindStatementText(stmt, 1, output.GetTxHash());
+            TryBindStatementInt64(stmt, 2, output.GetNumber());
+            TryBindStatementText(stmt, 3, output.GetAddressHash());
+            TryBindStatementInt64(stmt, 4, output.GetValue());
+            TryBindStatementText(stmt, 5, output.GetScriptPubKey());
 
             TryStepStatement(stmt);
         }

--- a/src/pocketdb/services/Serializer.cpp
+++ b/src/pocketdb/services/Serializer.cpp
@@ -39,16 +39,17 @@ namespace PocketServices
 
     // Serialize protocol compatible with Reindexer
     // It makes sense to serialize only Pocket transactions that contain a payload.
-    shared_ptr<UniValue> Serializer::SerializeBlock(const PocketBlock& block)
+    optional<UniValue> Serializer::SerializeBlock(const PocketBlock& block)
     {
-        auto result = make_shared<UniValue>(UniValue(UniValue::VOBJ));
+        // Need optional here?
+        UniValue result (UniValue::VOBJ);
         for (const auto& transaction : block)
         {
             auto dataPtr = SerializeTransaction(*transaction);
             if (!dataPtr)
                 continue;
 
-            result->pushKV(*transaction->GetHash(), dataPtr->write());
+            result.pushKV(*transaction->GetHash(), dataPtr->write());
         }
 
         return result;
@@ -56,18 +57,19 @@ namespace PocketServices
 
     // Serialize protocol compatible with Reindexer
     // It makes sense to serialize only Pocket transactions that contain a payload.
-    shared_ptr<UniValue> Serializer::SerializeTransaction(const Transaction& transaction)
+    optional<UniValue> Serializer::SerializeTransaction(const Transaction& transaction)
     {
-        if (!PocketHelpers::TransactionHelper::IsPocketTransaction(*transaction.GetType()))
-            return nullptr;
+        auto type = transaction.GetType();
+        if (!type || !PocketHelpers::TransactionHelper::IsPocketTransaction(*type))
+            return nullopt;
 
-        auto result = make_shared<UniValue>(UniValue(UniValue::VOBJ));
+        UniValue result (UniValue::VOBJ);
 
         auto serializedTransaction = transaction.Serialize();
         auto base64Transaction = EncodeBase64(serializedTransaction->write());
 
-        result->pushKV("t", PocketHelpers::TransactionHelper::ConvertToReindexerTable(transaction));
-        result->pushKV("d", base64Transaction);
+        result.pushKV("t", PocketHelpers::TransactionHelper::ConvertToReindexerTable(transaction));
+        result.pushKV("d", base64Transaction);
 
         return result;
     }
@@ -142,10 +144,10 @@ namespace PocketServices
         {
             const CTxIn& txin = tx->vin[i];
 
-            auto inp = make_shared<TransactionInput>();
-            inp->SetSpentTxHash(spentTxHash);
-            inp->SetTxHash(txin.prevout.hash.GetHex());
-            inp->SetNumber(txin.prevout.n);
+            auto inp = TransactionInput();
+            inp.SetSpentTxHash(spentTxHash);
+            inp.SetTxHash(txin.prevout.hash.GetHex());
+            inp.SetNumber(txin.prevout.n);
             
             ptx->Inputs().push_back(inp);
         }
@@ -161,11 +163,11 @@ namespace PocketServices
         {
             const CTxOut& txout = tx->vout[i];
 
-            auto out = make_shared<TransactionOutput>();
-            out->SetTxHash(txHash);
-            out->SetNumber((int) i);
-            out->SetValue(txout.nValue);
-            out->SetScriptPubKey(HexStr(txout.scriptPubKey));
+            auto out = TransactionOutput();
+            out.SetTxHash(txHash);
+            out.SetNumber((int) i);
+            out.SetValue(txout.nValue);
+            out.SetScriptPubKey(HexStr(txout.scriptPubKey));
 
             TxoutType type;
             std::vector <CTxDestination> vDest;
@@ -173,11 +175,11 @@ namespace PocketServices
             if (ExtractDestinations(txout.scriptPubKey, type, vDest, nRequired))
             {
                 for (const auto& dest : vDest)
-                    out->SetAddressHash(EncodeDestination(dest));
+                    out.SetAddressHash(EncodeDestination(dest));
             }
             else
             {
-                out->SetAddressHash("");
+                out.SetAddressHash("");
             }
 
             ptx->Outputs().push_back(out);

--- a/src/pocketdb/services/Serializer.h
+++ b/src/pocketdb/services/Serializer.h
@@ -31,8 +31,8 @@ namespace PocketServices
         static tuple<bool, PTransactionRef> DeserializeTransaction(const CTransactionRef& tx, CDataStream& stream);
         static tuple<bool, PTransactionRef> DeserializeTransaction(const CTransactionRef& tx);
 
-        static shared_ptr<UniValue> SerializeBlock(const PocketBlock& block);
-        static shared_ptr<UniValue> SerializeTransaction(const Transaction& transaction);
+        static optional<UniValue> SerializeBlock(const PocketBlock& block);
+        static optional<UniValue> SerializeTransaction(const Transaction& transaction);
 
     private:
         static shared_ptr<Transaction> buildInstance(const CTransactionRef& tx, const UniValue& src);

--- a/src/pocketdb/web/PocketExplorerRpc.cpp
+++ b/src/pocketdb/web/PocketExplorerRpc.cpp
@@ -699,10 +699,10 @@ namespace PocketWeb::PocketWebRpc
         {
             UniValue uinp(UniValue::VOBJ);
 
-            uinp.pushKV("txid", *inp->GetSpentTxHash());
-            uinp.pushKV("vout", *inp->GetNumber());
-            if (inp->GetAddressHash()) uinp.pushKV("address", *inp->GetAddressHash());
-            if (inp->GetValue()) uinp.pushKV("value", *inp->GetValue() / 100000000.0);
+            uinp.pushKV("txid", *inp.GetSpentTxHash());
+            uinp.pushKV("vout", *inp.GetNumber());
+            if (inp.GetAddressHash()) uinp.pushKV("address", *inp.GetAddressHash());
+            if (inp.GetValue()) uinp.pushKV("value", *inp.GetValue() / 100000000.0);
 
             utx.At("vin").push_back(uinp);
         }
@@ -712,17 +712,17 @@ namespace PocketWeb::PocketWebRpc
         for (const auto& out : ptx->Outputs())
         {
             UniValue uout(UniValue::VOBJ);
-            uout.pushKV("n", *out->GetNumber());
-            uout.pushKV("value", *out->GetValue() / 100000000.0);
+            uout.pushKV("n", *out.GetNumber());
+            uout.pushKV("value", *out.GetValue() / 100000000.0);
 
             UniValue scriptPubKey(UniValue::VOBJ);
             UniValue addresses(UniValue::VARR);
-            addresses.push_back(*out->GetAddressHash());
+            addresses.push_back(*out.GetAddressHash());
             scriptPubKey.pushKV("addresses", addresses);
-            scriptPubKey.pushKV("hex", *out->GetScriptPubKey());
+            scriptPubKey.pushKV("hex", *out.GetScriptPubKey());
             uout.pushKV("scriptPubKey", scriptPubKey);
 
-            if (out->GetSpentHeight()) uout.pushKV("spent", *out->GetSpentHeight());
+            if (out.GetSpentHeight()) uout.pushKV("spent", *out.GetSpentHeight());
 
             utx.At("vout").push_back(uout);
         }

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -309,7 +309,7 @@ bool CheckStakeKernelHash(CBlockIndex *pindexPrev, unsigned int nBits, CBlockInd
     bnTarget.SetCompact(nBits);
 
     // Weighted target
-    int64_t nValueIn = *txPrev.OutputsConst()[prevout.n]->GetValue();
+    int64_t nValueIn = *txPrev.OutputsConst()[prevout.n].GetValue();
     arith_uint256 bnWeight = std::min(nValueIn, Params().GetConsensus().nStakeMaximumThreshold);
     bnTarget *= bnWeight;
 
@@ -566,7 +566,7 @@ bool TransactionGetCoinAge(CTransactionRef transaction, uint64_t &nCoinAge, Chai
         if (pblockindex->nTime + Params().GetConsensus().nStakeMinAge > transaction->nTime)
             continue; // only count coins meeting min age requirement
 
-        int64_t nValueIn = *txPrev->OutputsConst()[txin.prevout.n]->GetValue();
+        int64_t nValueIn = *txPrev->OutputsConst()[txin.prevout.n].GetValue();
         bnCentSecond += CAmount(nValueIn) * (transaction->nTime - *txPrev->GetTime()) / (COIN / 100);
     }
 


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
<!--
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
-->
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- [...]

## Other comments:
Theoretically using optional instead of shared_ptr should have a performance boost because of all allocations happen at the stack, not the heap. Also, using optional by reference without copying should be much faster than copying the shared_ptr.
This PR should be tested very carefully, because:
- Previously shared_ptr was copied in a lot of places and used to obtain temporal reference to internal object, e.x. in `TryBindStatementText`. In this example sqlite doesn't obtain memory itself and just uses pointer the user give to it, so with optional we should be care that the object we pass to such functions will live until the function finished. To prevent error with `TryBindStatementText` optional is passed by rvalue-reference that prevents from passing a temporal copy of optional that could have been resulted in corrupted data in db. However, there can be potentially more places like this.
- We should avoid copying optional object where possible, because even that copying shared_ptr is long, it is faster than copying the entire object that is the case with optionals. Double check that there are no more unnecessary copies of optionals and everything is accessed by reference
