### PR TITLE
fix: log warning for deprecated zapwallettxes parameter instead stop node

### DIFF
--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -94,7 +94,7 @@ bool WalletInit::ParameterInteraction() const
     }
 
     if (gArgs.IsArgSet("-zapwallettxes")) {
-        return InitError(Untranslated("-zapwallettxes has been removed. If you are attempting to remove a stuck transaction from your wallet, please use abandontransaction instead."));
+        LogPrintf("Warning! -zapwallettxes has been removed. If you are attempting to remove a stuck transaction from your wallet, please use abandontransaction instead.\n");
     }
 
     if (gArgs.GetBoolArg("-sysperms", false))


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [X] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Comment
We need to solve the problem of canceled transactions without manual intervention, as this stops the work of staking.