### PR TITLE
fix: automatic creation and loading of the default wallet

### DIFF
--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -45,18 +45,11 @@ bool VerifyWallets(interfaces::Chain& chain)
     // For backwards compatibility if an unnamed top level wallet exists in the
     // wallets directory, include it in the default list of wallets to load.
     if (!gArgs.IsArgSet("wallet")) {
-        DatabaseOptions options;
-        DatabaseStatus status;
-        bilingual_str error_string;
-        options.require_existing = true;
-        options.verify = false;
-        if (MakeWalletDatabase("", options, status, error_string)) {
-            gArgs.LockSettings([&](util::Settings& settings) {
-                util::SettingsValue wallets(util::SettingsValue::VARR);
-                wallets.push_back(""); // Default wallet name is ""
-                settings.rw_settings["wallet"] = wallets;
-            });
-        }
+        gArgs.LockSettings([&](util::Settings& settings) {
+            util::SettingsValue wallets(util::SettingsValue::VARR);
+            wallets.push_back(""); // Default wallet name is ""
+            settings.rw_settings["wallet"] = wallets;
+        });
     }
 
     // Keep track of each wallet absolute path to detect duplicates.
@@ -72,7 +65,7 @@ bool VerifyWallets(interfaces::Chain& chain)
 
         DatabaseOptions options;
         DatabaseStatus status;
-        options.require_existing = true;
+        // options.require_existing = true;
         options.verify = true;
         bilingual_str error_string;
         if (!MakeWalletDatabase(wallet_file, options, status, error_string)) {
@@ -98,7 +91,7 @@ bool LoadWallets(interfaces::Chain& chain)
             }
             DatabaseOptions options;
             DatabaseStatus status;
-            options.require_existing = true;
+            // options.require_existing = true;
             options.verify = false; // No need to verify, assuming verified earlier in VerifyWallets()
             bilingual_str error;
             std::vector<bilingual_str> warnings;


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
<!--
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
-->
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- [...]

## Other comments:

- Bitcoin code around this has a very bad level of abstraction and i think it is impossible to do this more correct without a lot of refactoring. The fix is just "reverting" of https://github.com/bitcoin/bitcoin/pull/15454/.
- Default created wallet is stored in "settings" temporarily and is not stored on disk. However using `createwallet` rpc with `load_on_startup=true` will update settings with new wallet and dump them on disk, so default wallet will be dumped too. This is a bit unexpected behavior, that both wallets will be loaded on startup, however it shouldn't affect anything and user could remove default wallet persistence in settings by calling `unloadwallet "" false` rpc request. After that only the newly created wallet will be loaded on startup.
