### PR TITLE
fix: correctly relay transactions in _accept_transaction

### DIFF
--- a/src/pocketdb/web/PocketTransactionRpc.cpp
+++ b/src/pocketdb/web/PocketTransactionRpc.cpp
@@ -4,6 +4,7 @@
 
 #include "pocketdb/web/PocketTransactionRpc.h"
 #include "consensus/validation.h"
+#include "net_processing.h"
 #include "node/coin.h"
 #include "primitives/transaction.h"
 #include "rpc/blockchain.h"
@@ -390,6 +391,7 @@ namespace PocketWeb::PocketWebRpc
         };
     }
 
+    // TODO (losty): this is likely a duplicate of "BroadcastTransaction", consider using it instead of this.
     UniValue _accept_transaction(const CTransactionRef& tx, const PTransactionRef& ptx, CTxMemPool& mempool, CConnman& connman)
     {
         promise<void> promise;
@@ -463,11 +465,7 @@ namespace PocketWeb::PocketWebRpc
 
         promise.get_future().wait();
 
-        CInv inv(MSG_TX, txid);
-        connman.ForEachNode([&inv](CNode* pnode) {
-            // TODO (losty-fur): Validate this is working
-            pnode->PushTxInventory(inv.hash);
-        });
+        RelayTransaction(tx->GetHash(), tx->GetWitnessHash(), connman);
 
         return txid.GetHex();
     }


### PR DESCRIPTION
…saction

## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
<!--
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
-->
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- [...]

## Other comments:

This fix will allow to correctly relay transactions between 0.21 nodes because they require to use wtxid during relay (see [BIP-339](https://github.com/bitcoin/bips/blob/master/bip-0339.mediawiki) which has been already implemented for 0.21).
