### PR TITLE
fix: building removeHashes before iter invalidation in Expire (CleanSQLite)

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1090,13 +1090,13 @@ int CTxMemPool::Expire(std::chrono::seconds time)
     for (txiter removeit : toremove)
         CalculateDescendants(removeit, stage);
 
-    // Remove from memory mempool
-    RemoveStaged(stage, false, MemPoolRemovalReason::EXPIRY);
-
-    // Build list of tx hashes
+    // Build list of tx hashes for cleaning sqlite
     std::unordered_set<std::string> removeHashes;
     for (const auto& iter : stage)
         removeHashes.emplace(iter->GetTx().GetHash().GetHex());
+
+    // Remove from memory mempool
+    RemoveStaged(stage, false, MemPoolRemovalReason::EXPIRY);
 
     // Also remove from sqlite db
     CleanSQLite(removeHashes, MemPoolRemovalReason::EXPIRY);


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
<!--
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
-->
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- [...]

## Other comments:

`RemoveStaged()` method invalidated provided iterators and using them after is UB. So this PR collects `removeHashes` before calling `RemoveStaged()`
