### PR TITLE
Added stream and audio post types in WS notifications

### DIFF
--- a/src/pocketdb/consensus/social/Audio.hpp
+++ b/src/pocketdb/consensus/social/Audio.hpp
@@ -251,7 +251,7 @@ namespace PocketConsensus
     {
     private:
         const vector<ConsensusCheckpoint < AudioConsensus>> m_rules = {
-                { 9999999, 0, [](int height) { return make_shared<AudioConsensus>(height); }}, //TODO (o1q): change checkpoint height
+                { 9999999, 9999999, [](int height) { return make_shared<AudioConsensus>(height); }}, //TODO (o1q): change checkpoint height
         };
     public:
         shared_ptr<AudioConsensus> Instance(int height)

--- a/src/pocketdb/consensus/social/Stream.hpp
+++ b/src/pocketdb/consensus/social/Stream.hpp
@@ -251,7 +251,7 @@ namespace PocketConsensus
     {
     private:
         const vector<ConsensusCheckpoint < StreamConsensus>> m_rules = {
-                { 9999999, 0, [](int height) { return make_shared<StreamConsensus>(height); }}, //TODO (o1q): change checkpoint height
+                { 9999999, 9999999, [](int height) { return make_shared<StreamConsensus>(height); }}, //TODO (o1q): change checkpoint height
         };
     public:
         shared_ptr<StreamConsensus> Instance(int height)


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
<!--
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [ ] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- Disabling stream and audio post transactions
