### PR TITLE
feat: extended txunspent RPC

### DIFF
--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -1942,10 +1942,12 @@ namespace PocketDb
         return result;
     }
 
-    UniValue WebRpcRepository::GetUnspents(const vector<string>& addresses, int height,
-        vector<pair<string, uint32_t>>& mempoolInputs)
+    UniValue WebRpcRepository::GetUnspents(const vector<string>& addresses, int height, vector<pair<string, uint32_t>>& mempoolInputs,
+        int minConf, int maxConf, CAmount nMinimumAmount, CAmount  nMinimumSumAmount, int64_t nMaximumCount)
     {
         UniValue result(UniValue::VARR);
+
+        // TODO (aok): realize additional filter options
 
         string sql = R"sql(
             select

--- a/src/pocketdb/repositories/web/WebRpcRepository.h
+++ b/src/pocketdb/repositories/web/WebRpcRepository.h
@@ -98,7 +98,8 @@ namespace PocketDb
         vector<int64_t> GetContentIds(const vector<string>& txHashes);
         map<string,string> GetContentsAddresses(const vector<string>& txHashes);
 
-        UniValue GetUnspents(const vector<string>& addresses, int height, vector<pair<string, uint32_t>>& mempoolInputs);
+        UniValue GetUnspents(const vector<string>& addresses, int height, vector<pair<string, uint32_t>>& mempoolInputs,
+            int minConf, int maxConf, CAmount nMinimumAmount, CAmount  nMinimumSumAmount, int64_t nMaximumCount);
 
         tuple<int, UniValue> GetContentLanguages(int height);
         tuple<int, UniValue> GetLastAddressContent(const string& address, int height, int count);


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [X] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- Extended public API method txunspent for more flexible request configuration

## Other comments:

The arguments are taken from the original listunspent method
