### PR TITLE
fix: discovering pocketnet tests by absolute path

### DIFF
--- a/test/functional/pocketnet/test_runner.py
+++ b/test/functional/pocketnet/test_runner.py
@@ -36,7 +36,7 @@ BOLD = ("\033[0m", "\033[1m")
 
 def discover(tests_dir):
     dir_items = os.listdir(tests_dir)
-    scripts = [f for f in dir_items if os.path.isfile(f) and f.endswith(".py")]
+    scripts = [f for f in dir_items if os.path.isfile(os.path.join(tests_dir, f)) and f.endswith(".py")]
     tests = sorted(list(set(scripts) - set(NON_SCRIPTS)))
     print("\nDiscovered Tests:\n")
     for test in tests:


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
<!--
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
-->
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- [...]

## Other comments:

This change allow to call pocketnet test runner from any location instead of doing `cd test/functional/pocketnet/` every time
