### PR TITLE
Featute/newapimethod

### DIFF
--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -4745,7 +4745,7 @@ namespace PocketDb
                 and s.Height > 0
                 and s.String2 = ?
                 and exists(select 1
-                           from Transactions c
+                           from Transactions c indexed by Transactions_Type_Last_String1_Height_Id
                            where c.Type in (200, 201, 202, 209, 210)
                              and c.Last = 1
                              and c.Height > 0
@@ -4756,7 +4756,7 @@ namespace PocketDb
                 )sql" + addressPaginationFilter + R"sql(
 
                 -- Do not show posts from users with low reputation
-                and ifnull(ur.Value,0) > ?
+                -- and ifnull(ur.Value,0) > ?
 
                 order by s.String1
                 limit ?
@@ -4773,7 +4773,7 @@ namespace PocketDb
             TryBindStatementText(stmt, i++, address);
             TryBindStatementInt(stmt, i++, nHeight);
             if (!addressPagination.empty()) TryBindStatementText(stmt, i++, addressPagination);
-            TryBindStatementInt(stmt, i++, badReputationLimit);
+//            TryBindStatementInt(stmt, i++, badReputationLimit);
             TryBindStatementInt(stmt, i++, countOutOfUsers);
 
             // ---------------------------------------------
@@ -4782,8 +4782,8 @@ namespace PocketDb
             {
                 UniValue contents(UniValue::VOBJ);
 
-                if (auto[ok, value] = TryGetColumnInt(*stmt, 0); ok) contents.pushKV("address", value);
-                if (auto[ok, value] = TryGetColumnInt(*stmt, 1); ok) contents.pushKV("txids", value);
+                if (auto[ok, value] = TryGetColumnString(*stmt, 0); ok) contents.pushKV("address", value);
+                if (auto[ok, value] = TryGetColumnString(*stmt, 1); ok) contents.pushKV("txids", value);
 
                 result.push_back(contents);
             }

--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -4715,6 +4715,83 @@ namespace PocketDb
         return result;
     }
 
+    UniValue WebRpcRepository::GetsubsciptionsGroupedByAuthors(const string& address, const string& addressPagination, int nHeight, int countOutOfUsers, int countOutOfcontents, int badReputationLimit)
+    {
+        auto func = __func__;
+        UniValue result(UniValue::VARR);
+
+        string addressPaginationFilter;
+        if (!addressPagination.empty())
+            addressPaginationFilter += " and String1 > ? ";
+
+        string sql = R"sql(
+            select
+                String1 address,
+                       (select json_group_array(c.String2)
+                        from Transactions c indexed by Transactions_Type_Last_String1_Height_Id
+                        where c.Type in (200, 201, 202)
+                          and c.Last = 1
+                          and c.Height > 0
+                          and c.Height <= ?
+                          and c.String1 = s.String1
+                        order by c.id desc
+                        limit ?)
+
+            from Transactions s indexed by Transactions_Type_Last_String1_Height_Id
+
+            where s.Type in (302, 303)
+                and s.Last = 1
+                and tb.Height <= ?
+                and tb.Height > 0
+                and s.String2 = ?
+                and exists(select 1
+                           from Transactions c
+                           where c.Type in (200, 201, 202)
+                             and c.Last = 1
+                             and c.Height is not null
+                             and c.String1 = s.String1
+                           limit 1)
+
+                )sql" + addressPaginationFilter + R"sql(
+
+                -- Do not show posts from users with low reputation
+                and ifnull(ur.Value,0) > ?
+
+                order by s.String1
+                limit ?
+            )sql";
+
+        TryTransactionStep(func, [&]()
+        {
+            int i = 1;
+            auto stmt = SetupSqlStatement(sql);
+
+            TryBindStatementInt(stmt, i++, nHeight);
+            TryBindStatementInt(stmt, i++, countOutOfcontents);
+            TryBindStatementInt(stmt, i++, nHeight);
+            TryBindStatementText(stmt, i++, address);
+            if (!addressPagination.empty()) TryBindStatementText(stmt, i++, addressPagination);
+            TryBindStatementInt(stmt, i++, badReputationLimit);
+            TryBindStatementInt(stmt, i++, countOutOfUsers);
+
+            // ---------------------------------------------
+
+            while (sqlite3_step(*stmt) == SQLITE_ROW)
+            {
+                UniValue contents(UniValue::VOBJ);
+
+                if (auto[ok, value] = TryGetColumnInt(*stmt, 0); ok) contents.pushKV("address", value);
+                if (auto[ok, value] = TryGetColumnInt(*stmt, 1); ok) contents.pushKV("txids", value);
+
+                result.push_back(contents);
+            }
+
+            FinalizeSqlStatement(*stmt);
+        });
+
+        return result;
+    }
+
     // ------------------------------------------------------
 
     vector<int64_t> WebRpcRepository::GetRandomContentIds(const string& lang, int count, int height)

--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -4729,7 +4729,7 @@ namespace PocketDb
                 String1 address,
                        (select json_group_array(c.String2)
                         from Transactions c indexed by Transactions_Type_Last_String1_Height_Id
-                        where c.Type in (200, 201, 202)
+                        where c.Type in (200, 201, 202, 209, 210)
                           and c.Last = 1
                           and c.Height > 0
                           and c.Height <= ?
@@ -4741,14 +4741,15 @@ namespace PocketDb
 
             where s.Type in (302, 303)
                 and s.Last = 1
-                and tb.Height <= ?
-                and tb.Height > 0
+                and s.Height <= ?
+                and s.Height > 0
                 and s.String2 = ?
                 and exists(select 1
                            from Transactions c
-                           where c.Type in (200, 201, 202)
+                           where c.Type in (200, 201, 202, 209, 210)
                              and c.Last = 1
-                             and c.Height is not null
+                             and c.Height > 0
+                             and c.Height <= ?
                              and c.String1 = s.String1
                            limit 1)
 
@@ -4770,6 +4771,7 @@ namespace PocketDb
             TryBindStatementInt(stmt, i++, countOutOfcontents);
             TryBindStatementInt(stmt, i++, nHeight);
             TryBindStatementText(stmt, i++, address);
+            TryBindStatementInt(stmt, i++, nHeight);
             if (!addressPagination.empty()) TryBindStatementText(stmt, i++, addressPagination);
             TryBindStatementInt(stmt, i++, badReputationLimit);
             TryBindStatementInt(stmt, i++, countOutOfUsers);

--- a/src/pocketdb/repositories/web/WebRpcRepository.h
+++ b/src/pocketdb/repositories/web/WebRpcRepository.h
@@ -172,6 +172,8 @@ namespace PocketDb
                                        const vector<string>& adrsExcluded, const vector<string>& tagsExcluded, const string& address,
                                        const string& keyword, const string& orderby, const string& ascdesc);
 
+        UniValue GetsubsciptionsGroupedByAuthors(const string& address, const string& addressPagination, int nHeight, int countOutOfUsers, int countOutOfcontents, int badReputationLimit);
+
         /**
          * Returns map where key is address. Value is map, where key - height, value - vector of transactions for this height.
          */

--- a/src/pocketdb/web/PocketContentRpc.cpp
+++ b/src/pocketdb/web/PocketContentRpc.cpp
@@ -1639,10 +1639,10 @@ namespace PocketWeb::PocketWebRpc
                                   nHeight = request.params[2].get_int();
 
                               if (request.params.size() > 3 && request.params[3].isNum())
-                                  countOutOfUsers = std::max(request.params[3].get_int(), 100);
+                                  countOutOfUsers = std::min(request.params[3].get_int(), 100);
 
                               if (request.params.size() > 4 && request.params[4].isNum())
-                                  countOutOfcontents = std::max(request.params[4].get_int(), 1000);
+                                  countOutOfcontents = std::min(request.params[4].get_int(), 1000);
 
                               auto reputationConsensus = ReputationConsensusFactoryInst.Instance(ChainActive().Height());
                               auto badReputationLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_bad_reputation);

--- a/src/pocketdb/web/PocketContentRpc.cpp
+++ b/src/pocketdb/web/PocketContentRpc.cpp
@@ -1635,7 +1635,7 @@ namespace PocketWeb::PocketWebRpc
                               if (request.params.size() > 1 && request.params[1].isStr())
                                   addressPagination = request.params[1].get_str();
 
-                              if (request.params.size() > 2 && request.params[2].isNum() && request.params[2].get_int())
+                              if (request.params.size() > 2 && request.params[2].isNum() && request.params[2].get_int() > 0)
                                   nHeight = request.params[2].get_int();
 
                               if (request.params.size() > 3 && request.params[3].isNum())

--- a/src/pocketdb/web/PocketContentRpc.cpp
+++ b/src/pocketdb/web/PocketContentRpc.cpp
@@ -1596,4 +1596,64 @@ namespace PocketWeb::PocketWebRpc
     },
         };
     }
+
+    RPCHelpMan GetsubsciptionsGroupedByAuthors()
+    {
+        return RPCHelpMan{"GetsubsciptionsGroupedByAuthors",
+                          "\n\n", // TODO (rpc)
+                          {
+                                  {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "" /* TODO (rpc): arg description*/},
+                                  {"addressPagination", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "" /* TODO (rpc): arg description*/},
+                                  {"nHeight", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "" /*TODO (rpc): arg description*/},
+                                  {"countOutOfUsers", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "" /* TODO (rpc): arg description*/},
+                                  {"countOutOfcontents", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "" /* TODO (rpc): arg description*/}
+                          },
+                          {
+                                  // TODO (rpc): provide return description
+                          },
+                          RPCExamples{
+                                  // TODO (rpc): better examples
+                                  HelpExampleCli("getsubsciptionsgroupedbyauthors", "...") +
+                                  HelpExampleRpc("getsubsciptionsgroupedbyauthors", "...")
+                          },
+                          [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+                          {
+                              string address = "";
+                              string addressPagination = "";
+                              int nHeight = ChainActive().Height();
+                              int countOutOfUsers = 10;
+                              int countOutOfcontents = 10;
+
+                              UniValue result(UniValue::VOBJ);
+
+                              if (request.params.empty())
+                                  return result;
+
+                              if (request.params[0].isStr())
+                                  address = request.params[0].get_str();
+
+                              if (request.params.size() > 1 && request.params[1].isStr())
+                                  addressPagination = request.params[1].get_str();
+
+                              if (request.params.size() > 2 && request.params[2].isNum() && request.params[2].get_int())
+                                  nHeight = request.params[2].get_int();
+
+                              if (request.params.size() > 3 && request.params[3].isNum())
+                                  countOutOfUsers = std::max(request.params[3].get_int(), 100);
+
+                              if (request.params.size() > 4 && request.params[4].isNum())
+                                  countOutOfcontents = std::max(request.params[4].get_int(), 1000);
+
+                              auto reputationConsensus = ReputationConsensusFactoryInst.Instance(ChainActive().Height());
+                              auto badReputationLimit = reputationConsensus->GetConsensusLimit(ConsensusLimit_bad_reputation);
+
+                              UniValue content = request.DbConnection()->WebRpcRepoInst->GetsubsciptionsGroupedByAuthors(
+                                      address, addressPagination, nHeight, countOutOfUsers, countOutOfcontents, badReputationLimit);
+
+                              result.pushKV("height", nHeight);
+                              result.pushKV("contents", content);
+                              return result;
+                          },
+        };
+    }
 }

--- a/src/pocketdb/web/PocketContentRpc.h
+++ b/src/pocketdb/web/PocketContentRpc.h
@@ -34,6 +34,7 @@ namespace PocketWeb::PocketWebRpc
     RPCHelpMan GetNotifications();
     RPCHelpMan GetActivities();
     RPCHelpMan GetNotificationsSummary();
+    RPCHelpMan GetsubsciptionsGroupedByAuthors();
 }
 
 #endif //SRC_POCKETDEBUG_H

--- a/src/pocketdb/web/PocketRpc.cpp
+++ b/src/pocketdb/web/PocketRpc.cpp
@@ -74,6 +74,7 @@ static const CRPCCommand commands[] =
     {"contents",        "getactivities",                    &GetActivities,                 {"address", "height", "blockNum", "filters"}},
     {"contents",        "getnotifications",                 &GetNotifications,              {"height", "filters"}},
     {"contents",        "getnotificationssummary",          &GetNotificationsSummary,       {"addresses", "height", "filters"}},
+    {"contents",        "getsubsciptionsgroupedbyauthors",  &GetsubsciptionsGroupedByAuthors, {"address", "addressPagination", "nHeight", "countOutOfUsers", "countOutOfcontents"}},
 
     // Tags
 //    {"artifacts", "searchtags",                       &gettemplate,                       {"search_string", "count"}},


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

API method getsubsciptionsgroupedbyauthors - returns subscribers with their publication
Input prams:
- address - string, required. Address for which the selection is being made
- addressPagination - string, optional. Pagination address (last address from previous page)
- nHeight - int, optional. Block number for which the selection is being made (Default is 0 - last block)
- countOutOfUsers - int, optional. Number of subscribers in output (Default is 10)
- countOutOfcontents - int, optional. Number of contents for each subscriber in output (Default is 10)

## Other comments:

...
