### PR TITLE
fix: revert have_data logic to origin in FindNextBlocksToDownload

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -856,39 +856,10 @@ static void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vec
                 return;
             }
 
-            // We need recheck all pocketnet data exists
-            bool block_have_data = pindex->nStatus & BLOCK_HAVE_DATA;
-            // if (pindex->nStatus & BLOCK_HAVE_DATA)
-            // {
-            //     block_have_data = true;
-
-            //     CBlock block;
-            //     if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus()))
-            //     {
-            //         block_have_data = false;
-            //         LogPrintf("FindNextBlocksToDownload Don't read block from disk %d -> %s\n", pindex->nHeight, pindex->GetBlockHash().GetHex());
-            //     }
-                    
-            //     if (block_have_data)
-            //     {
-            //         std::vector<std::string> txHashes;
-            //         for (const auto& tx : block.vtx)
-            //             if (!tx->IsCoinBase())
-            //                 txHashes.push_back(tx->GetHash().GetHex());
-
-            //         block_have_data = PocketServices::Accessor::ExistsTransactions(txHashes);
-            //         LogPrintf("FindNextBlocksToDownload ExistsTransactions %d -> %d\n", pindex->nHeight, block_have_data);
-            //         if (!block_have_data)
-            //             LogPrintf("FindNextBlocksToDownload Don't exists all txs in sqlite %d -> %s\n", pindex->nHeight, pindex->GetBlockHash().GetHex());
-            //     }
-            // }
-            // else
-            // {
-            //     LogPrintf("FindNextBlocksToDownload Don't BLOCK_HAVE_DATA %d -> %s\n", pindex->nHeight, pindex->GetBlockHash().GetHex());
-            // }
-
-            if ((block_have_data || ::ChainActive().Contains(pindex)) && pindex->HaveTxsDownloaded()) {
-                state->pindexLastCommonBlock = pindex;
+            // TODO (losty): this works untill we do not clean sql mempool!!!
+            if (pindex->nStatus & BLOCK_HAVE_DATA || ::ChainActive().Contains(pindex)) {
+                if (pindex->HaveTxsDownloaded())
+                    state->pindexLastCommonBlock = pindex;
             } else if (mapBlocksInFlight.count(pindex->GetBlockHash()) == 0) {
                 // The block is not already downloaded, and not yet in flight.
                 if (pindex->nHeight > nWindowEnd) {


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
<!--
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
-->
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- [...]

## Other comments:

The presented logic can is not working well in some situations because of bad concurrences with cleaning sql mempool logic.
