### PR TITLE
consensus: disable 1-2-3 scores for trial users

### DIFF
--- a/doc/pips.md
+++ b/doc/pips.md
@@ -3,3 +3,4 @@ PIPs that are implemented by Pocketcoin Core:
 * [`PIP 100`](): Changes in the policy of emission payments. ([PR #563](https://github.com/pocketnetteam/pocketnet.core/wiki/PIP-100:-Changes-in-emission-payments))
 * [`PIP 101`](): Correction of incorrect blocking logic. ([PR #589](https://github.com/pocketnetteam/pocketnet.core/wiki/PIP-101:-Correction-of-incorrect-blocking-logic))
 * [`PIP 102`](): Correction of incorrect complain logic. ([PR #588](https://github.com/pocketnetteam/pocketnet.core/wiki/PIP-102:-Correction-of-incorrect-complain-logic))
+* [`PIP 103`](): Disable ratings (3) for trial users. ([PR #588](https://github.com/pocketnetteam/pocketnet.core/wiki/PIP-103:-Disable-ratings-(3)-for-trial-users))

--- a/doc/pips.md
+++ b/doc/pips.md
@@ -3,4 +3,4 @@ PIPs that are implemented by Pocketcoin Core:
 * [`PIP 100`](): Changes in the policy of emission payments. ([PR #563](https://github.com/pocketnetteam/pocketnet.core/wiki/PIP-100:-Changes-in-emission-payments))
 * [`PIP 101`](): Correction of incorrect blocking logic. ([PR #589](https://github.com/pocketnetteam/pocketnet.core/wiki/PIP-101:-Correction-of-incorrect-blocking-logic))
 * [`PIP 102`](): Correction of incorrect complain logic. ([PR #588](https://github.com/pocketnetteam/pocketnet.core/wiki/PIP-102:-Correction-of-incorrect-complain-logic))
-* [`PIP 103`](): Disable ratings (3) for trial users. ([PR #588](https://github.com/pocketnetteam/pocketnet.core/wiki/PIP-103:-Disable-ratings-(3)-for-trial-users))
+* [`PIP 103`](): Disable ratings (3) for trial users. ([PR #611](https://github.com/pocketnetteam/pocketnet.core/wiki/PIP-103:-Disable-ratings-(3)-for-trial-users))

--- a/src/pocketdb/consensus/social/ScoreContent.hpp
+++ b/src/pocketdb/consensus/social/ScoreContent.hpp
@@ -255,9 +255,7 @@ namespace PocketConsensus
         }
     };
 
-    /*******************************************************************************************************************
-    *  Start checkpoint at 1324655 block
-    *******************************************************************************************************************/
+    // Disable 1-2 scores for trial users
     class ScoreContentConsensus_checkpoint_1324655 : public ScoreContentConsensus_checkpoint_1180000
     {
     public:
@@ -289,6 +287,18 @@ namespace PocketConsensus
         }
     };
 
+    // Disable 1-2-3 scores for trial users
+    class ScoreContentConsensus_checkpoint_pip_103 : public ScoreContentConsensus_checkpoint_disable_for_blocked
+    {
+    public:
+        ScoreContentConsensus_checkpoint_pip_103() : ScoreContentConsensus_checkpoint_disable_for_blocked() {}
+    protected:
+        bool ValidateLowReputation(const ScoreContentRef& ptx, AccountMode mode) override
+        {
+            return mode != AccountMode_Trial || *ptx->GetValue() > 3;
+        }
+    };
+
 
     // ----------------------------------------------------------------------------------------------
     // Factory for select actual rules version
@@ -297,13 +307,14 @@ namespace PocketConsensus
     public:
         ScoreContentConsensusFactory()
         {
-            Checkpoint({       0,     -1, -1, make_shared<ScoreContentConsensus>() });
-            Checkpoint({  430000,     -1, -1, make_shared<ScoreContentConsensus_checkpoint_430000>() });
-            Checkpoint({  514184,     -1, -1, make_shared<ScoreContentConsensus_checkpoint_514184>() });
-            Checkpoint({ 1124000,     -1, -1, make_shared<ScoreContentConsensus_checkpoint_1124000>() });
-            Checkpoint({ 1180000,      0, -1, make_shared<ScoreContentConsensus_checkpoint_1180000>() });
-            Checkpoint({ 1324655,  65000, -1, make_shared<ScoreContentConsensus_checkpoint_1324655>() });
-            Checkpoint({ 1757000, 953000,  0, make_shared<ScoreContentConsensus_checkpoint_disable_for_blocked>() });
+            Checkpoint({       0,      -1, -1, make_shared<ScoreContentConsensus>() });
+            Checkpoint({  430000,      -1, -1, make_shared<ScoreContentConsensus_checkpoint_430000>() });
+            Checkpoint({  514184,      -1, -1, make_shared<ScoreContentConsensus_checkpoint_514184>() });
+            Checkpoint({ 1124000,      -1, -1, make_shared<ScoreContentConsensus_checkpoint_1124000>() });
+            Checkpoint({ 1180000,       0, -1, make_shared<ScoreContentConsensus_checkpoint_1180000>() });
+            Checkpoint({ 1324655,   65000, -1, make_shared<ScoreContentConsensus_checkpoint_1324655>() });
+            Checkpoint({ 1757000,  953000, -1, make_shared<ScoreContentConsensus_checkpoint_disable_for_blocked>() });
+            Checkpoint({ 2516000, 2267333,  0, make_shared<ScoreContentConsensus_checkpoint_pip_103>() });
         }
     };
 

--- a/src/pocketdb/repositories/web/WebRpcRepository.h
+++ b/src/pocketdb/repositories/web/WebRpcRepository.h
@@ -88,8 +88,8 @@ namespace PocketDb
         UniValue GetSubscribersAddresses(
             const string& address, const vector<TxType>& types = {ACTION_SUBSCRIBE, ACTION_SUBSCRIBE_PRIVATE },
             const string& orderBy = "height", bool orderDesc = true, int offset = 0, int limit = 10);
-        UniValue GetBlockings(const string& address);
-        UniValue GetBlockers(const string& address);
+        UniValue GetBlockings(const string& address, bool useAddresses);
+        UniValue GetBlockers(const string& address, bool useAddresses);
 
         vector<string> GetTopAccounts(int topHeight, int countOut, const string& lang,
         const vector<string>& tags, const vector<int>& contentTypes,

--- a/src/pocketdb/web/PocketAccountRpc.cpp
+++ b/src/pocketdb/web/PocketAccountRpc.cpp
@@ -712,6 +712,7 @@ namespace PocketWeb::PocketWebRpc
                 "\nReturn blocked accounts list\n",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
+                    {"useaddresses", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "Use addresses instead numbers"},
                 },
                 {
                     // TODO (rpc): provide return description
@@ -727,7 +728,16 @@ namespace PocketWeb::PocketWebRpc
 
         string address = request.params[0].get_str();
 
-        return request.DbConnection()->WebRpcRepoInst->GetBlockings(address);
+        bool useAddresses = false;
+        if (request.params.size() > 1)
+        {
+            if (request.params[1].isBool())
+                useAddresses = request.params[1].get_bool();
+            else if (request.params[1].isNum())
+                useAddresses = (request.params[1].get_int() == 1);
+        }
+
+        return request.DbConnection()->WebRpcRepoInst->GetBlockings(address, useAddresses);
     },
         };
     }
@@ -738,6 +748,7 @@ namespace PocketWeb::PocketWebRpc
                 "\nReturns a list of accounts that have blocked the specified address\n",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
+                    {"useaddresses", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "Use addresses instead numbers"},
                 },
                 {
                     // TODO (rpc): provide return description
@@ -752,7 +763,17 @@ namespace PocketWeb::PocketWebRpc
         RPCTypeCheck(request.params, {UniValue::VSTR});
 
         string address = request.params[0].get_str();
-        return request.DbConnection()->WebRpcRepoInst->GetBlockers(address);
+
+        bool useAddresses = false;
+        if (request.params.size() > 1)
+        {
+            if (request.params[1].isBool())
+                useAddresses = request.params[1].get_bool();
+            else if (request.params[1].isNum())
+                useAddresses = (request.params[1].get_int() == 1);
+        }
+
+        return request.DbConnection()->WebRpcRepoInst->GetBlockers(address, useAddresses);
     },
         };
     }

--- a/src/pocketdb/web/PocketRpc.cpp
+++ b/src/pocketdb/web/PocketRpc.cpp
@@ -96,8 +96,8 @@ static const CRPCCommand commands[] =
     {"accounts",        "getuserstatistic",                 &GetAccountStatistic,            {"address", "height", "depth"}},
     {"accounts",        "getusersubscribes",                &GetAccountSubscribes,           {"address", "orderby", "orderdesc", "offset", "limit"}},
     {"accounts",        "getusersubscribers",               &GetAccountSubscribers,          {"address", "orderby", "orderdesc", "offset", "limit"}},
-    {"accounts",        "getuserblockings",                 &GetAccountBlockings,            {"address"}},
-    {"accounts",        "getuserblockers",                  &GetAccountBlockers,             {"address"}},
+    {"accounts",        "getuserblockings",                 &GetAccountBlockings,            {"address","useaddresses"}},
+    {"accounts",        "getuserblockers",                  &GetAccountBlockers,             {"address","useaddresses"}},
     {"accounts",        "gettopaccounts",                   &GetTopAccounts,                 {"topHeight","countOut","lang","tags","contentTypes","adrsExcluded","tagsExcluded","depth"}},
 
     // Scores


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [X] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new classes, methods, I provide a valid use case for all of them.

### Comment
There are also present changes for RPC methods for getting custom locks and getuserblockers