### PR TITLE
fix: ban old forked nodes #605

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -57,6 +57,17 @@ static CBlock CreateGenesisBlock(uint32_t nTime, uint32_t nNonce, uint32_t nBits
     return CreateGenesisBlock(pszTimestamp, genesisOutputScript, nTime, nNonce, nBits, nVersion, genesisReward);
 }
 
+int SocialForks::GetLastAcceptedSubVersion(int height) const
+{
+    // TODO (losty): optimize
+    auto res = m_forkPoints.end();
+    for (auto itr = m_forkPoints.begin(); itr != m_forkPoints.end(); itr++) {
+        if (itr->GetHeight(Params().NetworkID()) < height)
+            res = itr;
+    }
+    return res != m_forkPoints.end() ? res->GetVersion() : 0;
+}
+
 /**
  * Main network
  */
@@ -136,8 +147,6 @@ public:
         m_assumed_blockchain_size = 50; // 50 is ok for now
         m_assumed_chain_state_size = 0; // We do not use prune
                                         //
-        nLastSocialForkVersion = 210300;
-        nLastSocialForkActivationHeight = 2360000;
 
         genesis = CreateGenesisBlock(1548092268, 234579, 0x1e0fffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -180,9 +180,9 @@ protected:
     CCheckpointData checkpointData;
     ChainTxData chainTxData;
     SocialForks socialForks = {{
-        // TODO (release): fulfill
+        // TODO (release): check (may be fulfill with earlier forks)
         {210300 /* 0.21.3 */, 2360000, 1950500, 0},
-        {220000 /* 0.22 */, 2800000, 2500000, 0} // TODO (losty): fix
+        {220000 /* 0.22 */, 2552000, 2267333, 0}
     }};
 };
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2553,7 +2553,7 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
             vRecv >> LIMITED_STRING(strSubVer, MAX_SUBVERSION_LENGTH);
             cleanSubVer = SanitizeString(strSubVer);
         }
-        if (gArgs.GetBoolArg("-disconnectold", DEFAULT_DISCONNECT_OLD) && DeformatSubVersion(cleanSubVer) < Params().LastSocialForkVersion() && ChainActive().Height() > Params().LastSocialForkActivationHeight()) {
+        if (gArgs.GetBoolArg("-disconnectold", DEFAULT_DISCONNECT_OLD) && DeformatSubVersion(cleanSubVer) < Params().Forks().GetLastAcceptedSubVersion(ChainActive().Height())) {
             LogPrint(BCLog::NET, "peer=%d using outdated version %s and potentially could be forked %i; disconnecting\n", pfrom.GetId(), cleanSubVer);
             pfrom.fDisconnect = true;
             return;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2555,6 +2555,7 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
         }
         if (gArgs.GetBoolArg("-disconnectold", DEFAULT_DISCONNECT_OLD) && DeformatSubVersion(cleanSubVer) < Params().Forks().GetLastAcceptedSubVersion(ChainActive().Height())) {
             LogPrint(BCLog::NET, "peer=%d using outdated version %s and potentially could be forked %i; disconnecting\n", pfrom.GetId(), cleanSubVer);
+            m_banman->Ban(pfrom.addr, 60 * 60 /* 1 hour */);
             pfrom.fDisconnect = true;
             return;
         }

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -468,7 +468,7 @@ endif()
 if(WIN32)
     target_sources(pocketcoin-qt PRIVATE ${POCKETCOIN_RC})
 endif()
-target_link_libraries(pocketcoin-qt PRIVATE qt_libpocketcoinqt ${POCKETCOIN_SERVER} ${POCKETCOIN_UTIL} leveldb libpocketcoin_cli)
+target_link_libraries(pocketcoin-qt PRIVATE qt_libpocketcoinqt ${POCKETCOIN_SERVER} ${POCKETCOIN_UTIL} leveldb libpocketcoin_cli OpenSSL::SSL OpenSSL::Crypto)
 # target_include_directories(pocketcoin-qt PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
 
 target_compile_definitions(qt_libpocketcoinqt PRIVATE QT_NO_KEYWORDS)


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [ ] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- Handle fork history
- Not only disconnect, but ban old nodes for 1 hour
- Fix build qt with cmake

## Other comments:

Fork history will allow to prevent situation when new fork with new height is specified and all old nodes that should have been banned will become relevant until new fork appears.

Also banning for an hour is too long i think so the banned peer will be unable to participate in network for an hour after update but on the other side not all nodes will enable this feature and there lots of very old nodes that haven't updated for a **lot** of time and it is meaningless to ban them for small time.

Related to #605 