### PR TITLE
fix: update GitHub API URL in PocketcoinApplication for fix checking updates

### DIFF
--- a/src/qt/pocketcoin.cpp
+++ b/src/qt/pocketcoin.cpp
@@ -450,10 +450,10 @@ void PocketcoinApplication::getLatestVersionFinished() {
                 int latest_version = new_tag_name.replace(QString("v"), QString("")).replace(QString("."), QString("")).toInt();;
 
                 if (latest_version > current_version) {
-                    qWarning() << "Check updates result: a new version is available (https://github.com/bitnetteam/bitnet.core/releases/latest)";
+                    qWarning() << "Check updates result: a new version is available (https://api.github.com/repos/pocketnetteam/pocketnet.core/releases/latest)";
 
                     update_dlg = new UpdateNotificationDialog(
-                        QString("https://github.com/bitnetteam/bitnet.core/releases/latest"),
+                        QString("https://api.github.com/repos/pocketnetteam/pocketnet.core/releases/latest"),
                         (QString::number(CLIENT_VERSION_MAJOR) + "." + QString::number(CLIENT_VERSION_MINOR) + "." + QString::number(CLIENT_VERSION_REVISION)),
                         json_obj["tag_name"].toString().replace(QString("v"), QString("")),
                         nullptr
@@ -462,7 +462,7 @@ void PocketcoinApplication::getLatestVersionFinished() {
                     update_dlg->exec();
                     update_dlg->setFocus();
                 } else {
-                    qWarning() << "Check updates result: no new versions (https://github.com/bitnetteam/bitnet.core/releases/latest)";
+                    qWarning() << "Check updates result: no new versions (https://api.github.com/repos/pocketnetteam/pocketnet.core/releases/latest)";
                 }
             } else {
                 qWarning() << "Check updates result: invalid json: " << json_data;
@@ -483,7 +483,7 @@ void PocketcoinApplication::checkLatestRelease() {
 
         QNetworkAccessManager* network_manager = new QNetworkAccessManager(this);
         QNetworkRequest request;
-        request.setUrl(QUrl("https://api.github.com/repos/bitnetapp/bitnet.core/releases/latest"));
+        request.setUrl(QUrl("https://api.github.com/repos/pocketnetteam/pocketnet.core/releases/latest"));
         request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
         
         QNetworkReply* reply = network_manager->get(request);


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [X] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Description:
These edits eliminate the error:
```
2023-12-25T16:58:56Z GUI: Check updates result: error:  QNetworkReply::NetworkError(ProtocolUnknownError)
```