### PR TITLE
fix: hide banned accounts from feeds

### DIFF
--- a/src/pocketdb/repositories/web/ModerationRepository.cpp
+++ b/src/pocketdb/repositories/web/ModerationRepository.cpp
@@ -306,6 +306,7 @@ namespace PocketDb
                     )
                     select
                         (select r.String from Registry r where r.RowId = f.RowId) as JuryId,
+                        (select r.String from Registry r where r.RowId = f.RegId2) as ContentId,
                         f.Int1 as Reason,
                         b.Ending
                     from
@@ -337,9 +338,11 @@ namespace PocketDb
                         
                         if (auto[ok, value] = cursor.TryGetColumnString(0); ok)
                             record.pushKV("juryId", value);
-                        if (auto[ok, value] = cursor.TryGetColumnInt(1); ok)
+                        if (auto[ok, value] = cursor.TryGetColumnString(1); ok)
+                            record.pushKV("contentId", value);
+                        if (auto[ok, value] = cursor.TryGetColumnInt(2); ok)
                             record.pushKV("reason", value);
-                        if (auto[ok, value] = cursor.TryGetColumnInt64(2); ok)
+                        if (auto[ok, value] = cursor.TryGetColumnInt64(3); ok)
                             record.pushKV("ending", value);
                         
                         result.push_back(record);

--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -962,7 +962,7 @@ namespace PocketDb
                 ,ifnull((select Data from web.AccountStatistic a where a.AccountRegId = addr.id and a.Type = 5), '{}') as FlagsJson
                 ,ifnull((select Data from web.AccountStatistic a where a.AccountRegId = addr.id and a.Type = 6), '{}') as FirstFlagsCount
                 ,ifnull((select Data from web.AccountStatistic a where a.AccountRegId = addr.id and a.Type = 7), 0) as ActionsCount
-                ,(select json_group_object(jb.VoteRowId, jb.Ending) from JuryBan jb where jb.AccountId = cu.Uid) as Bans
+                ,(select json_group_object((select r.String from Registry r where r.RowId = jb.VoteRowId), jb.Ending) from JuryBan jb where jb.AccountId = cu.Uid) as Bans
 
             from
                 addr,

--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -627,6 +627,12 @@ namespace PocketDb
                             if (auto [ok, value] = cursor.TryGetColumnInt64(i++); ok)
                                 record.pushKV("actions", value);
 
+                            if (auto [ok, value] = cursor.TryGetColumnString(i++); ok) {
+                                UniValue flags(UniValue::VOBJ);
+                                flags.read(value);
+                                record.pushKV("bans", flags);
+                            }
+
                             if (!shortForm) {
 
                                 if (auto [ok, value] = cursor.TryGetColumnString(i++); ok) {
@@ -956,6 +962,7 @@ namespace PocketDb
                 ,ifnull((select Data from web.AccountStatistic a where a.AccountRegId = addr.id and a.Type = 5), '{}') as FlagsJson
                 ,ifnull((select Data from web.AccountStatistic a where a.AccountRegId = addr.id and a.Type = 6), '{}') as FirstFlagsCount
                 ,ifnull((select Data from web.AccountStatistic a where a.AccountRegId = addr.id and a.Type = 7), 0) as ActionsCount
+                ,(select json_group_object(jb.VoteRowId, jb.Ending) from JuryBan jb where jb.AccountId = cu.Uid) as Bans
 
             from
                 addr,

--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -4046,11 +4046,19 @@ namespace PocketDb
                         JuryBan jb on
                             jb.AccountId = cu.Uid and
                             jb.Ending > ?
+                    left join
+                        Jury j on
+                            j.AccountId = cu.Uid
+                    left join
+                        JuryVerdict jv on
+                            jv.FlagRowId = j.FlagRowId
                     where
                         -- Do not show posts from users with low reputation
                         ifnull(ur.Value,0) > ?
                         -- Do not show posts from banned users
                         and jb.AccountId is null
+                        -- Do not show posts from users with active jury
+                        and jv.RowId is null
                     order by
                         r.Value desc
                     limit ?
@@ -4562,6 +4570,12 @@ namespace PocketDb
                 JuryBan jb on
                     jb.AccountId = cu.Uid and
                     jb.Ending > ?
+            left join
+                Jury j on
+                    j.AccountId = cu.Uid
+            left join
+                JuryVerdict jv on
+                    jv.FlagRowId = j.FlagRowId
             where
 
                     ct.Height > ?
@@ -4572,6 +4586,9 @@ namespace PocketDb
 
                 -- Do not show posts from banned users
                 and jb.AccountId is null
+
+                -- Do not show posts from users with active jury
+                and jv.RowId is null
 
                 -- Skip ids for pagination
                 )sql" + skipPaginationSql + R"sql(
@@ -4795,6 +4812,12 @@ namespace PocketDb
                 JuryBan jb on
                     jb.AccountId = cu.Uid and
                     jb.Ending > ?
+            left join
+                Jury j on
+                    j.AccountId = cu.Uid
+            left join
+                JuryVerdict jv on
+                    jv.FlagRowId = j.FlagRowId
             where
 
                     ct.Height > ?
@@ -4805,6 +4828,9 @@ namespace PocketDb
 
                 -- Do not show posts from banned users
                 and jb.AccountId is null
+
+                -- Do not show posts from users with active jury
+                and jv.RowId is null
 
                 -- Skip ids for pagination
                 )sql" + skipPaginationSql + R"sql(
@@ -5233,12 +5259,21 @@ namespace PocketDb
                 JuryBan jb on
                     jb.AccountId = cu.Uid and
                     jb.Ending > ?
+            left join
+                Jury j on
+                    j.AccountId = cu.Uid
+            left join
+                JuryVerdict jv on
+                    jv.FlagRowId = j.FlagRowId
             where
                 t.Type in ( )sql" + join(vector<string>(contentTypes.size(), "?"), ",") + R"sql( )
                 and t.RegId3 is null
 
                 -- Do not show posts from banned users
                 and jb.AccountId is null
+
+                -- Do not show posts from users with active jury
+                and jv.RowId is null
 
                 -- Skip ids for pagination
                 )sql" + skipPaginationSql + R"sql(
@@ -5454,6 +5489,12 @@ namespace PocketDb
                 JuryBan jb on
                     jb.AccountId = cu.Uid and
                     jb.Ending > ?
+            left join
+                Jury j on
+                    j.AccountId = cu.Uid
+            left join
+                JuryVerdict jv on
+                    jv.FlagRowId = j.FlagRowId
             where
                 t.Type in ( )sql" + join(vector<string>(contentTypes.size(), "?"), ",") + R"sql( )
                 and t.RegId3 is null
@@ -5463,6 +5504,9 @@ namespace PocketDb
 
                 -- Do not show posts from banned users
                 and jb.AccountId is null
+
+                -- Do not show posts from users with active jury
+                and jv.RowId is null
 
                 -- Skip ids for pagination
                 )sql" + skipPaginationSql + R"sql(
@@ -5674,6 +5718,12 @@ namespace PocketDb
                 JuryBan jb on
                     jb.AccountId = cu.Uid and
                     jb.Ending > ?
+            left join
+                Jury j on
+                    j.AccountId = cu.Uid
+            left join
+                JuryVerdict jv on
+                    jv.FlagRowId = j.FlagRowId
             where
                 ct.Height > ?
                 and ct.Height <= ?
@@ -5683,6 +5733,9 @@ namespace PocketDb
 
                 -- Do not show posts from banned users
                 and jb.AccountId is null
+
+                -- Do not show posts from users with active jury
+                and jv.RowId is null
 
                 -- Exclude posts
                 and t.RegId2 not in (
@@ -5958,23 +6011,37 @@ namespace PocketDb
                 JuryBan jb on
                     jb.AccountId = cu.Uid and
                     jb.Ending > heightMax.value
+            left join
+                Jury j on
+                    j.AccountId = cu.Uid
+            left join
+                JuryVerdict jv on
+                    jv.FlagRowId = j.FlagRowId
             where
                 tb.Type in ( 208 )
+
                 -- Do not show posts from users with low reputation
                 and ifnull(ur.Value, 0) > minReputation.value
+
                 -- Do not show posts from banned users
                 and jb.AccountId is null
+
+                -- Do not show posts from users with active jury
+                and jv.RowId is null
+
                 -- Other excludes
                 and tc.RegId2 not in (
                     select RowId
                     from Registry
                     where String in ( )sql" + join(vector<string>(txidsExcluded.size(), "?"), ",") + R"sql( )
                 )
+
                 and tc.RegId1 not in (
                     select RowId
                     from Registry
                     where String in ( )sql" + join(vector<string>(addrsExcluded.size(), "?"), ",") + R"sql( )
                 )
+
             group by
                 ctc.Uid,
                 tb.RegId2

--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -4058,7 +4058,7 @@ namespace PocketDb
                         -- Do not show posts from banned users
                         and jb.AccountId is null
                         -- Do not show posts from users with active jury
-                        and jv.RowId is null
+                        and jv.FlagRowId is null
                     order by
                         r.Value desc
                     limit ?
@@ -4588,7 +4588,7 @@ namespace PocketDb
                 and jb.AccountId is null
 
                 -- Do not show posts from users with active jury
-                and jv.RowId is null
+                and jv.FlagRowId is null
 
                 -- Skip ids for pagination
                 )sql" + skipPaginationSql + R"sql(
@@ -4830,7 +4830,7 @@ namespace PocketDb
                 and jb.AccountId is null
 
                 -- Do not show posts from users with active jury
-                and jv.RowId is null
+                and jv.FlagRowId is null
 
                 -- Skip ids for pagination
                 )sql" + skipPaginationSql + R"sql(
@@ -5273,7 +5273,7 @@ namespace PocketDb
                 and jb.AccountId is null
 
                 -- Do not show posts from users with active jury
-                and jv.RowId is null
+                and jv.FlagRowId is null
 
                 -- Skip ids for pagination
                 )sql" + skipPaginationSql + R"sql(
@@ -5506,7 +5506,7 @@ namespace PocketDb
                 and jb.AccountId is null
 
                 -- Do not show posts from users with active jury
-                and jv.RowId is null
+                and jv.FlagRowId is null
 
                 -- Skip ids for pagination
                 )sql" + skipPaginationSql + R"sql(
@@ -5735,7 +5735,7 @@ namespace PocketDb
                 and jb.AccountId is null
 
                 -- Do not show posts from users with active jury
-                and jv.RowId is null
+                and jv.FlagRowId is null
 
                 -- Exclude posts
                 and t.RegId2 not in (
@@ -6027,7 +6027,7 @@ namespace PocketDb
                 and jb.AccountId is null
 
                 -- Do not show posts from users with active jury
-                and jv.RowId is null
+                and jv.FlagRowId is null
 
                 -- Other excludes
                 and tc.RegId2 not in (


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [X] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- We hide banned accounts or with active jury from all feeds
- Added a list of banns with the end block to the short profile