### PR TITLE
fix: speeding up the execution of GetAddressTransactions requests

### DIFF
--- a/src/pocketdb/migrations/main.cpp
+++ b/src/pocketdb/migrations/main.cpp
@@ -392,6 +392,7 @@ namespace PocketDb
             drop index if exists Chain_Height_BlockId;
             drop index if exists TxInputs_TxId_Number;
             drop index if exists TxInputs_SpentTxId_TxId_Number;
+            drop index if exists TxOutputs_AddressId_TxId_Number;
 
             create index if not exists Chain_Uid_Height on Chain (Uid, Height);
             create index if not exists Chain_Height_Uid on Chain (Height, Uid);
@@ -417,7 +418,7 @@ namespace PocketDb
             create index if not exists TxInputs_TxId_Number_SpentTxId on TxInputs (TxId, Number, SpentTxId);
 
             create index if not exists TxOutputs_TxId_Number_AddressId on TxOutputs (TxId, Number, AddressId);
-            create index if not exists TxOutputs_AddressId_TxId_Number on TxOutputs (AddressId, TxId, Number);
+            create index if not exists TxOutputs_AddressId_TxIdDesc_Number on TxOutputs (AddressId, TxId desc, Number);
 
             create unique index if not exists Lists_TxId_OrderIndex_RegId on Lists (TxId, OrderIndex asc, RegId);
 

--- a/src/pocketdb/repositories/web/NotifierRepository.cpp
+++ b/src/pocketdb/repositories/web/NotifierRepository.cpp
@@ -505,7 +505,7 @@ namespace PocketDb
                             select
                                 o.Value
                             from
-                                TxOutputs o indexed by TxOutputs_AddressId_TxId_Number
+                                TxOutputs o indexed by TxOutputs_AddressId_TxIdDesc_Number
                             where
                                 o.AddressId = content.RegId1 and
                                 o.TxId = comment.RowId and

--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -1058,7 +1058,7 @@ namespace PocketDb
 
                         (
                             select o.Value
-                            from TxOutputs o indexed by TxOutputs_AddressId_TxId_Number
+                            from TxOutputs o indexed by TxOutputs_AddressId_TxIdDesc_Number
                             where o.TxId = t.RowId and o.AddressId = p.RegId1 and o.AddressId != t.RegId1
                             limit 1
                         ) as Donate
@@ -1433,7 +1433,7 @@ namespace PocketDb
                     on ct.TxId = t.RowId
             left join Transactions sc indexed by Transactions_Type_RegId2_RegId1
                 on sc.Type in (301) and sc.RegId2 = c.RegId2 and sc.RegId1 = addr.id and exists (select 1 from Chain csc where csc.TxId = sc.RowId)
-            left join TxOutputs o indexed by TxOutputs_AddressId_TxId_Number
+            left join TxOutputs o indexed by TxOutputs_AddressId_TxIdDesc_Number
                 on o.TxId = r.RowId and o.AddressId = t.RegId1 and o.AddressId != c.RegId1
             where
                 -- exclude commenters blocked by the author of the post
@@ -1698,7 +1698,7 @@ namespace PocketDb
                     left join
                         Transactions sc indexed by Transactions_Type_RegId1_RegId2_RegId3
                             on sc.Type in (301) and sc.RegId1 = addr.id and sc.RegId2 = c.RegId2 and exists (select 1 from Chain csc where csc.TxId = sc.RowId)
-                    left join TxOutputs o indexed by TxOutputs_AddressId_TxId_Number
+                    left join TxOutputs o indexed by TxOutputs_AddressId_TxIdDesc_Number
                         on o.TxId = r.RowId and o.AddressId = t.RegId1 and o.AddressId != c.RegId1
                 )sql")
                 .Bind(addressHash, cmntHashes, cmntIds);
@@ -2779,7 +2779,7 @@ namespace PocketDb
                         t.Type,
                         c.Height
                     from addr
-                    join TxOutputs o indexed by TxOutputs_AddressId_TxId_Number on
+                    join TxOutputs o indexed by TxOutputs_AddressId_TxIdDesc_Number on
                         o.AddressId = addr.id and not exists (select 1 from TxInputs i where i.TxId = o.TxId and i.Number = o.Number)
                     join Chain c on
                         c.TxId = o.TxId and c.Height <= ?
@@ -2865,7 +2865,7 @@ namespace PocketDb
                     from
                         addr
                     cross join
-                        TxOutputs o indexed by TxOutputs_AddressId_TxId_Number on
+                        TxOutputs o indexed by TxOutputs_AddressId_TxIdDesc_Number on
                             o.AddressId = addr.id
                     cross join
                         Chain c on
@@ -3450,7 +3450,7 @@ namespace PocketDb
                         addr,
                         height
                     cross join
-                        TxOutputs o indexed by TxOutputs_AddressId_TxId_Number
+                        TxOutputs o indexed by TxOutputs_AddressId_TxIdDesc_Number
                             on o.AddressId = addr.id
                     cross join
                         Chain c indexed by Chain_TxId_Height
@@ -3606,7 +3606,7 @@ namespace PocketDb
                         (select r.String from Registry r where r.RowId = c.RegId5) as  answerid,
                         (
                             select o.Value
-                            from TxOutputs o indexed by TxOutputs_AddressId_TxId_Number
+                            from TxOutputs o indexed by TxOutputs_AddressId_TxIdDesc_Number
                             where o.TxId = c.RowId and o.AddressId = p.RegId1 and o.AddressId != c.RegId1
                         ) as Donate
                     from
@@ -6537,7 +6537,7 @@ namespace PocketDb
                                 Last lp on
                                     lp.TxId = p.RowId
                             cross join
-                                TxOutputs o indexed by TxOutputs_AddressId_TxId_Number on
+                                TxOutputs o indexed by TxOutputs_AddressId_TxIdDesc_Number on
                                     o.AddressId = p.RegId1 and
                                     o.AddressId != c.RegId1 and
                                     o.TxId = c.RowId and
@@ -9063,7 +9063,7 @@ namespace PocketDb
 
                     from
                         params,
-                        TxOutputs o indexed by TxOutputs_AddressId_TxId_Number
+                        TxOutputs o indexed by TxOutputs_AddressId_TxIdDesc_Number
 
                         join Transactions t not indexed on
                             t.RowId = o.TxId and


### PR DESCRIPTION
…ns performance

## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [X] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

In this fix, the sorting of the transaction selection has been changed, because sorting by height and number in a block does not use indexes. Sorting by transaction RowId is faster, but it can cause problems with displaying transactions chronologically, since RowId is the internal value of a specific instance. I consider this uncritical, as long as there are no other ideas to optimize this query.