### PR TITLE
User-Space, Statically Defined Tracing (USDT)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,12 @@ AC_ARG_ENABLE([wallet],
 #   [use_sqlite=auto])
 use_sqlite=yes
 
+AC_ARG_ENABLE([usdt],
+  [AS_HELP_STRING([--enable-usdt],
+  [enable tracepoints for Userspace, Statically Defined Tracing (default is yes if sys/sdt.h is found)])],
+  [use_usdt=$enableval],
+  [use_usdt=yes])
+
 AC_ARG_WITH([miniupnpc],
   [AS_HELP_STRING([--with-miniupnpc],
   [enable UPNP (default is yes if libminiupnpc is found)])],
@@ -1240,6 +1246,24 @@ if test x$enable_wallet != xno; then
     fi
 fi
 
+if test "$use_usdt" != "no"; then
+  AC_MSG_CHECKING([whether Userspace, Statically Defined Tracing tracepoints are supported])
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM(
+      [// Setting SDT_USE_VARIADIC lets systemtap (sys/sdt.h) know that we want to use
+       // the optional variadic macros to define tracepoints.
+       #define SDT_USE_VARIADIC 1
+       #include <sys/sdt.h>],
+      [STAP_PROBEV(context, event);
+       int a, b, c, d, e, f, g;
+       STAP_PROBEV(context, event, a, b, c, d, e, f, g);]
+    )],
+    [AC_MSG_RESULT([yes]); AC_DEFINE([ENABLE_TRACING], [1], [Define to 1 to enable tracepoints for Userspace, Statically Defined Tracing])],
+    [AC_MSG_RESULT([no]); use_usdt=no;]
+  )
+fi
+AM_CONDITIONAL([ENABLE_USDT_TRACEPOINTS], [test "$use_usdt" = "yes"])
+
 dnl Check for libminiupnpc (optional)
 if test x$use_upnp != xno; then
   AC_CHECK_HEADERS(
@@ -1753,6 +1777,7 @@ fi
 echo "  with bench    = $use_bench"
 echo "  with upnp     = $use_upnp"
 echo "  use asm       = $use_asm"
+echo "  USDT tracing  = $use_usdt"
 echo "  sanitizers    = $use_sanitizers"
 echo "  debug enabled = $enable_debug"
 echo "  gprof enabled = $enable_gprof"

--- a/contrib/tracing/README.md
+++ b/contrib/tracing/README.md
@@ -1,0 +1,338 @@
+Example scripts for User-space, Statically Defined Tracing (USDT)
+=================================================================
+
+This directory contains scripts showcasing User-space, Statically Defined
+Tracing (USDT) support for Pocketnet Core on Linux using. For more information on
+USDT support in Pocketnet Core see the [USDT documentation].
+
+[USDT documentation]: ../../doc/tracing.md
+
+
+Examples for the two main eBPF front-ends, [bpftrace] and
+[BPF Compiler Collection (BCC)], with support for USDT, are listed. BCC is used
+for complex tools and daemons and `bpftrace` is preferred for one-liners and
+shorter scripts.
+
+[bpftrace]: https://github.com/iovisor/bpftrace
+[BPF Compiler Collection (BCC)]: https://github.com/iovisor/bcc
+
+
+To develop and run bpftrace and BCC scripts you need to install the
+corresponding packages. See [installing bpftrace] and [installing BCC] for more
+information. For development there exist a [bpftrace Reference Guide], a
+[BCC Reference Guide], and a [bcc Python Developer Tutorial].
+
+[installing bpftrace]: https://github.com/iovisor/bpftrace/blob/master/INSTALL.md
+[installing BCC]: https://github.com/iovisor/bcc/blob/master/INSTALL.md
+[bpftrace Reference Guide]: https://github.com/iovisor/bpftrace/blob/master/docs/reference_guide.md
+[BCC Reference Guide]: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md
+[bcc Python Developer Tutorial]: https://github.com/iovisor/bcc/blob/master/docs/tutorial_bcc_python_developer.md
+
+## Examples
+
+The bpftrace examples contain a relative path to the `pocketcoind` binary. By
+default, the scripts should be run from the repository-root and assume a
+self-compiled `pocketcoind` binary. The paths in the examples can be changed, for
+example, to point to release builds if needed. See the
+[Pocketnet Core USDT documentation] on how to list available tracepoints in your
+`pocketcoind` binary.
+
+[Pocketnet Core USDT documentation]: ../../doc/tracing.md#listing-available-tracepoints
+
+**WARNING: eBPF programs require root privileges to be loaded into a Linux
+kernel VM. This means the bpftrace and BCC examples must be executed with root
+privileges. Make sure to carefully review any scripts that you run with root
+privileges first!**
+
+### log_p2p_traffic.bt
+
+A bpftrace script logging information about inbound and outbound P2P network
+messages. Based on the `net:inbound_message` and `net:outbound_message`
+tracepoints.
+
+By default, `bpftrace` limits strings to 64 bytes due to the limited stack size
+in the eBPF VM. For example, Tor v3 addresses exceed the string size limit which
+results in the port being cut off during logging. The string size limit can be
+increased with the `BPFTRACE_STRLEN` environment variable (`BPFTRACE_STRLEN=70`
+works fine).
+
+```
+$ bpftrace contrib/tracing/log_p2p_traffic.bt
+```
+
+Output
+```
+outbound 'ping' msg to peer 11 (outbound-full-relay, [2a02:b10c:f747:1:ef:fake:ipv6:addr]:8333) with 8 bytes
+inbound 'pong' msg from peer 11 (outbound-full-relay, [2a02:b10c:f747:1:ef:fake:ipv6:addr]:8333) with 8 bytes
+inbound 'inv' msg from peer 16 (outbound-full-relay, XX.XX.XXX.121:8333) with 37 bytes
+outbound 'getdata' msg to peer 16 (outbound-full-relay, XX.XX.XXX.121:8333) with 37 bytes
+inbound 'tx' msg from peer 16 (outbound-full-relay, XX.XX.XXX.121:8333) with 222 bytes
+outbound 'inv' msg to peer 9 (outbound-full-relay, faketorv3addressa2ufa6odvoi3s77j4uegey0xb10csyfyve2t33curbyd.onion:8333) with 37 bytes
+outbound 'inv' msg to peer 7 (outbound-full-relay, XX.XX.XXX.242:8333) with 37 bytes
+…
+```
+
+### p2p_monitor.py
+
+A BCC Python script using curses for an interactive P2P message monitor. Based
+on the `net:inbound_message` and `net:outbound_message` tracepoints.
+
+Inbound and outbound traffic is listed for each peer together with information
+about the connection. Peers can be selected individually to view recent P2P
+messages.
+
+```
+$ python3 contrib/tracing/p2p_monitor.py $(pidof pocketcoind)
+```
+
+Lists selectable peers and traffic and connection information.
+```
+ P2P Message Monitor
+ Navigate with UP/DOWN or J/K and select a peer with ENTER or SPACE to see individual P2P messages
+
+ PEER  OUTBOUND              INBOUND               TYPE                   ADDR
+    0  46          398 byte  61      1407590 byte  block-relay-only       XX.XX.XXX.196:8333
+   11  1156     253570 byte  3431    2394924 byte  outbound-full-relay    XXX.X.XX.179:8333
+   13  3425    1809620 byte  1236     305458 byte  inbound                XXX.X.X.X:60380
+   16  1046     241633 byte  1589    1199220 byte  outbound-full-relay    4faketorv2pbfu7x.onion:8333
+   19  577      181679 byte  390      148951 byte  outbound-full-relay    kfake4vctorjv2o2.onion:8333
+   20  11         1248 byte  13         1283 byte  block-relay-only       [2600:fake:64d9:b10c:4436:aaaa:fe:bb]:8333
+   21  11         1248 byte  13         1299 byte  block-relay-only       XX.XXX.X.155:8333
+   22  5           103 byte  1           102 byte  feeler                 XX.XX.XXX.173:8333
+   23  11         1248 byte  12         1255 byte  block-relay-only       XX.XXX.XXX.220:8333
+   24  3           103 byte  1           102 byte  feeler                 XXX.XXX.XXX.64:8333
+…
+```
+
+Showing recent P2P messages between our node and a selected peer.
+
+```
+    ----------------------------------------------------------------------
+    |                PEER 16 (4faketorv2pbfu7x.onion:8333)               |
+    | OUR NODE                outbound-full-relay                   PEER |
+    |                                           <--- sendcmpct (9 bytes) |
+    | inv (37 byte) --->                                                 |
+    |                                                <--- ping (8 bytes) |
+    | pong (8 byte) --->                                                 |
+    | inv (37 byte) --->                                                 |
+    |                                               <--- addr (31 bytes) |
+    | inv (37 byte) --->                                                 |
+    |                                       <--- getheaders (1029 bytes) |
+    | headers (1 byte) --->                                              |
+    |                                           <--- feefilter (8 bytes) |
+    |                                                <--- pong (8 bytes) |
+    |                                            <--- headers (82 bytes) |
+    |                                            <--- addr (30003 bytes) |
+    | inv (1261 byte) --->                                               |
+    |                                 …                                  |
+
+```
+
+### log_raw_p2p_msgs.py
+
+A BCC Python script showcasing eBPF and USDT limitations when passing data
+larger than about 32kb. Based on the `net:inbound_message` and
+`net:outbound_message` tracepoints.
+
+Pocketnet P2P messages can be larger than 32kb (e.g. `tx`, `block`, ...). The
+eBPF VM's stack is limited to 512 bytes, and we can't allocate more than about
+32kb for a P2P message in the eBPF VM. The **message data is cut off** when the
+message is larger than MAX_MSG_DATA_LENGTH (see script). This can be detected
+in user-space by comparing the data length to the message length variable. The
+message is cut off when the data length is smaller than the message length.
+A warning is included with the printed message data.
+
+Data is submitted to user-space (i.e. to this script) via a ring buffer. The
+throughput of the ring buffer is limited. Each p2p_message is about 32kb in
+size. In- or outbound messages submitted to the ring buffer in rapid
+succession fill the ring buffer faster than it can be read. Some messages are
+lost. BCC prints: `Possibly lost 2 samples` on lost messages.
+
+
+```
+$ python3 contrib/tracing/log_raw_p2p_msgs.py $(pidof pocketcoind)
+```
+
+```
+Logging raw P2P messages.
+Messages larger that about 32kb will be cut off!
+Some messages might be lost!
+ outbound msg 'inv' from peer 4 (outbound-full-relay, XX.XXX.XX.4:8333) with 253 bytes: 0705000000be2245c8f844c9f763748e1a7…
+…
+Warning: incomplete message (only 32568 out of 53552 bytes)! inbound msg 'tx' from peer 32 (outbound-full-relay, XX.XXX.XXX.43:8333) with 53552 bytes: 020000000001fd3c01939c85ad6756ed9fc…
+…
+Possibly lost 2 samples
+```
+
+### connectblock_benchmark.bt
+
+A `bpftrace` script to benchmark the `ConnectBlock()` function during, for
+example, a blockchain re-index. Based on the `validation:block_connected` USDT
+tracepoint.
+
+The script takes three positional arguments. The first two arguments, the start,
+and end height indicate between which blocks the benchmark should be run. The
+third acts as a duration threshold in milliseconds. When the `ConnectBlock()`
+function takes longer than the threshold, information about the block, is
+printed. For more details, see the header comment in the script.
+
+The following command can be used to benchmark, for example, `ConnectBlock()`
+between height 20000 and 38000 on SigNet while logging all blocks that take
+longer than 25ms to connect.
+
+```
+$ bpftrace contrib/tracing/connectblock_benchmark.bt 20000 38000 25
+```
+
+In a different terminal, starting Pocketnet Core in SigNet mode and with
+re-indexing enabled.
+
+```
+$ ./build/src/pocketcoind -signet -reindex
+```
+
+This produces the following output.
+```
+Attaching 5 probes...
+ConnectBlock Benchmark between height 20000 and 38000 inclusive
+Logging blocks taking longer than 25 ms to connect.
+Starting Connect Block Benchmark between height 20000 and 38000.
+BENCH   39 blk/s     59 tx/s      59 inputs/s       20 sigops/s (height 20038)
+Block 20492 (000000f555653bb05e2f3c6e79925e01a20dd57033f4dc7c354b46e34735d32b)    20 tx   2319 ins   2318 sigops  took   38 ms
+BENCH 1840 blk/s   2117 tx/s    4478 inputs/s     2471 sigops/s (height 21879)
+BENCH 1816 blk/s   4972 tx/s    4982 inputs/s      125 sigops/s (height 23695)
+BENCH 2095 blk/s   2890 tx/s    2910 inputs/s      152 sigops/s (height 25790)
+BENCH 1684 blk/s   3979 tx/s    4053 inputs/s      288 sigops/s (height 27474)
+BENCH 1155 blk/s   3216 tx/s    3252 inputs/s      115 sigops/s (height 28629)
+BENCH 1797 blk/s   2488 tx/s    2503 inputs/s      111 sigops/s (height 30426)
+BENCH 1849 blk/s   6318 tx/s    6569 inputs/s    12189 sigops/s (height 32275)
+BENCH  946 blk/s  20209 tx/s   20775 inputs/s    83809 sigops/s (height 33221)
+Block 33406 (0000002adfe4a15cfcd53bd890a89bbae836e5bb7f38bac566f61ad4548c87f6)    25 tx   2045 ins   2090 sigops  took   29 ms
+Block 33687 (00000073231307a9828e5607ceb8156b402efe56747271a4442e75eb5b77cd36)    52 tx   1797 ins   1826 sigops  took   26 ms
+BENCH  582 blk/s  21581 tx/s   27673 inputs/s    60345 sigops/s (height 33803)
+BENCH 1035 blk/s  19735 tx/s   19776 inputs/s    51355 sigops/s (height 34838)
+Block 35625 (0000006b00b347390c4768ea9df2655e9ff4b120f29d78594a2a702f8a02c997)    20 tx   3374 ins   3371 sigops  took   49 ms
+BENCH  887 blk/s  17857 tx/s   22191 inputs/s    24404 sigops/s (height 35725)
+Block 35937 (000000d816d13d6e39b471cd4368db60463a764ba1f29168606b04a22b81ea57)    75 tx   3943 ins   3940 sigops  took   61 ms
+BENCH  823 blk/s  16298 tx/s   21031 inputs/s    18440 sigops/s (height 36548)
+Block 36583 (000000c3e260556dbf42968aae3f904dba8b8c1ff96a6f6e3aa5365d2e3ad317)    24 tx   2198 ins   2194 sigops  took   34 ms
+Block 36700 (000000b3b173de9e65a3cfa738d976af6347aaf83fa17ab3f2a4d2ede3ddfac4)    73 tx   1615 ins   1611 sigops  took   31 ms
+Block 36832 (0000007859578c02c1ac37dabd1b9ec19b98f350b56935f5dd3a41e9f79f836e)    34 tx   1440 ins   1436 sigops  took   26 ms
+BENCH  613 blk/s  16718 tx/s   25074 inputs/s    23022 sigops/s (height 37161)
+Block 37870 (000000f5c1086291ba2d943fb0c3bc82e71c5ee341ee117681d1456fbf6c6c38)    25 tx   1517 ins   1514 sigops  took   29 ms
+BENCH  811 blk/s  16031 tx/s   20921 inputs/s    18696 sigops/s (height 37972)
+
+Took 14055 ms to connect the blocks between height 20000 and 38000.
+
+Histogram of block connection times in milliseconds (ms).
+@durations:
+[0]                16838 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[1]                  882 |@@                                                  |
+[2, 4)               236 |                                                    |
+[4, 8)                23 |                                                    |
+[8, 16)                9 |                                                    |
+[16, 32)               9 |                                                    |
+[32, 64)               4 |                                                    |
+```
+
+### log_utxocache_flush.py
+
+A BCC Python script to log the UTXO cache flushes. Based on the
+`utxocache:flush` tracepoint.
+
+```bash
+$ python3 contrib/tracing/log_utxocache_flush.py $(pidof pocketcoind)
+```
+
+```
+Logging utxocache flushes. Ctrl-C to end...
+Duration (µs)   Mode       Coins Count     Memory Usage    Prune
+730451          IF_NEEDED  22990           3323.54 kB      True
+637657          ALWAYS     122320          17124.80 kB     False
+81349           ALWAYS     0               1383.49 kB      False
+```
+
+### log_utxos.bt
+
+A `bpftrace` script to log information about the coins that are added, spent, or
+uncached from the UTXO set. Based on the `utxocache:add`, `utxocache:spend` and
+`utxocache:uncache` tracepoints.
+
+```bash
+$ bpftrace contrib/tracing/log_utxos.bt
+```
+
+This should produce an output similar to the following. If you see bpftrace
+warnings like `Lost 24 events`, the eBPF perf ring-buffer is filled faster
+than it is being read. You can increase the ring-buffer size by setting the
+ENV variable `BPFTRACE_PERF_RB_PAGES` (default 64) at a cost of higher
+memory usage. See the [bpftrace reference guide] for more information.
+
+[bpftrace reference guide]: https://github.com/iovisor/bpftrace/blob/master/docs/reference_guide.md#98-bpftrace_perf_rb_pages
+
+```bash
+Attaching 4 probes...
+OP      Outpoint                                                                           Value  Height Coinbase
+Added   6ba9ad857e1ef2eb2a2c94f06813c414c7ab273e3d6bd7ad64e000315a887e7c:1                 10000 2094512 No
+Spent   fa7dc4db56637a151f6649d8f26732956d1c5424c82aae400a83d02b2cc2c87b:0             182264897 2094512 No
+Added   eeb2f099b1af6a2a12e6ddd2eeb16fc5968582241d7f08ba202d28b60ac264c7:0                 10000 2094512 No
+Added   eeb2f099b1af6a2a12e6ddd2eeb16fc5968582241d7f08ba202d28b60ac264c7:1             182254756 2094512 No
+Added   a0c7f4ec9cccef2d89672a624a4e6c8237a17572efdd4679eea9e9ee70d2db04:0              10072679 2094513 Yes
+Spent   25e0df5cc1aeb1b78e6056bf403e5e8b7e41f138060ca0a50a50134df0549a5e:2                   540 2094508 No
+Spent   42f383c04e09c26a2378272ec33aa0c1bf4883ca5ab739e8b7e06be5a5787d61:1               3848399 2007724 No
+Added   f85e3b4b89270863a389395cc9a4123e417ab19384cef96533c6649abd6b0561:0               3788399 2094513 No
+Added   f85e3b4b89270863a389395cc9a4123e417ab19384cef96533c6649abd6b0561:2                   540 2094513 No
+Spent   a05880b8c77971ed0b9f73062c7c4cdb0ff3856ab14cbf8bc481ed571cd34b83:1            5591281046 2094511 No
+Added   eb689865f7d957938978d6207918748f74e6aa074f47874724327089445b0960:0            5589696005 2094513 No
+Added   eb689865f7d957938978d6207918748f74e6aa074f47874724327089445b0960:1               1565556 2094513 No
+```
+
+### mempool_monitor.py
+
+A BCC Python script producing mempool statistics and an event log. Based on the
+`mempool:added`, `mempool:removed`, `mempool:replaced`, and `mempool:rejected`
+tracepoints.
+
+Statistics include incidence and rate for each event type since the script was
+started (`total`) as well as during the last minute (`1 min`) and ten minutes
+(`10 min`). The event log shows mempool events in real time, each entry
+comprising a timestamp along with all event data available via the event's
+tracepoint.
+
+```console
+$ python3 contrib/tracing/mempool_monitor.py $(pidof pocketcoind)
+```
+
+```
+ Mempool Monitor
+ Press CTRL-C to stop.
+
+ ┌─Event count───────────────────────┐  ┌─Event rate──────────────────────────┐
+ │ Event       total   1 min  10 min │  │ Event       total    1 min   10 min │
+ │ added      1425tx   201tx  1425tx │  │ added     4.7tx/s  3.4tx/s  4.7tx/s │
+ │ removed      35tx     4tx    35tx │  │ removed   0.1tx/s  0.1tx/s  0.1tx/s │
+ │ replaced     35tx     4tx    35tx │  │ replaced  0.1tx/s  0.1tx/s  0.1tx/s │
+ │ rejected      0tx     0tx     0tx │  │ rejected  0.0tx/s  0.0tx/s  0.0tx/s │
+ └───────────────────────────────────┘  └─────────────────────────────────────┘
+
+ ┌─Event log────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+ │ 13:10:30Z added f9064ca5bfc87cdd191faa42bf697217cd920b2b94838c1f1192e4f06c4fd217 with feerate 8.92 sat/vB (981 sat, 110 vbytes)                                              │
+ │ 13:10:30Z added 53ffa3afbe57b1bfe423e1755ca2b52c5b6cb4aa91b8b7ee9cb694953f47f234 with feerate 5.00 sat/vB (550 sat, 110 vbytes)                                              │
+ │ 13:10:30Z added 4177df5e19465eb5e53c3f8b6830a293f57474921bc6c2ae89375e0986e1f0f9 with feerate 2.98 sat/vB (429 sat, 144 vbytes)                                              │
+ │ 13:10:30Z added 931a10d83f0a268768da75dc4b9e199f2f055f12979ae5491cc304ee10f890ea with feerate 3.55 sat/vB (500 sat, 141 vbytes)                                              │
+ │ 13:10:30Z added 4cf32b295723cc4ab73f2a2e51d4bb276c0042760a4c00a3eb9595b8ebb24721 with feerate 89.21 sat/vB (12668 sat, 142 vbytes)                                           │
+ │ 13:10:31Z replaced d1eecf9d662121322f4f31f0c2267a752d14bb3956e6016ba96e87f47890e1db with feerate 27.12 sat/vB received 23.3 seconds ago (7213 sat, 266 vbytes) with c412db908│
+ │ 9b7ed53f3e5e36d2819dd291278b59ccaabaeb17fd37c3d87fdcd57 with feerate 28.12 sat/vB (8351 sat, 297 vbytes)                                                                     │
+ │ 13:10:31Z added c412db9089b7ed53f3e5e36d2819dd291278b59ccaabaeb17fd37c3d87fdcd57 with feerate 28.12 sat/vB (8351 sat, 297 vbytes)                                            │
+ │ 13:10:31Z added b8388a5bdc421b11460bdf477d5a85a1a39c2784e7dd7bffabe688740424ea57 with feerate 25.21 sat/vB (3554 sat, 141 vbytes)                                            │
+ │ 13:10:31Z added 4ddb88bc90a122cd9eae8a664e73bdf5bebe75f3ef901241b4a251245854a98e with feerate 24.15 sat/vB (5072 sat, 210 vbytes)                                            │
+ │ 13:10:31Z added 19101e4161bca5271ad5d03e7747f2faec7793b274dc2f3c4cf516b7cef1aac3 with feerate 7.06 sat/vB (1080 sat, 153 vbytes)                                             │
+ │ 13:10:31Z removed d1eecf9d662121322f4f31f0c2267a752d14bb3956e6016ba96e87f47890e1db with feerate 27.12 sat/vB (7213 sat, 266 vbytes): replaced                                │
+ │ 13:10:31Z added 6c511c60d9b95b9eff81df6ecba5c86780f513fe62ce3ad6be2c5340d957025a with feerate 4.00 sat/vB (440 sat, 110 vbytes)                                              │
+ │ 13:10:31Z added 44d66f7f004bd52c46be4dff3067cab700e51c7866a84282bd8aab560a5bfb79 with feerate 3.15 sat/vB (448 sat, 142 vbytes)                                              │
+ │ 13:10:31Z added b17b7c9ec5acfbbf12f0eeef8e29826fad3105bb95eef7a47d2f1f22b4784643 with feerate 4.10 sat/vB (1348 sat, 329 vbytes)                                             │
+ │ 13:10:31Z added b7a4ad93554e57454e8a8049bfc0bd803fa962bd3f0a08926aa72e7cb23e2276 with feerate 1.01 sat/vB (205 sat, 202 vbytes)                                              │
+ │ 13:10:32Z added c78e87be86c828137a6e7e00a177c03b52202ce4c39029b99904c2a094b9da87 with feerate 11.00 sat/vB (1562 sat, 142 vbytes)                                            │
+ │                                                                                                                                                                              │
+ └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```

--- a/contrib/tracing/README.md
+++ b/contrib/tracing/README.md
@@ -336,3 +336,22 @@ $ python3 contrib/tracing/mempool_monitor.py $(pidof pocketcoind)
  │                                                                                                                                                                              │
  └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
+### log_p2p_connections.bt
+A `bpftrace` script to log information about opened, closed, misbehaving, and
+evicted P2P connections. Uses the `net:*_connection` tracepoints.
+```bash
+$ bpftrace contrib/tracing/log_p2p_connections.bt
+```
+
+This should produce an output similar to the following.
+
+```bash
+Attaching 6 probes...
+Logging opened, closed, misbehaving, and evicted P2P connections
+OUTBOUND conn to 127.0.0.1:15287: id=0, type=block-relay-only, network=0, total_out=1
+INBOUND conn from 127.0.0.1:45324: id=1, type=inbound, network=0, total_in=1
+MISBEHAVING conn id=1, score_before=0, score_increase=20, message='getdata message size = 50001', threshold_exceeded=false
+CLOSED conn to 127.0.0.1:15287: id=0, type=block-relay-only, network=0, established=1231006505
+EVICTED conn to 127.0.0.1:45324: id=1, type=inbound, network=0, established=1612312312
+...
+```

--- a/contrib/tracing/log_p2p_connections.bt
+++ b/contrib/tracing/log_p2p_connections.bt
@@ -1,0 +1,51 @@
+#!/usr/bin/env bpftrace
+
+BEGIN
+{
+  printf("Logging opened, closed, misbehaving, and evicted P2P connections\n")
+}
+
+usdt:./build/src/bitcoind:net:inbound_connection
+{
+  $id = (int64) arg0;
+  $addr = str(arg1);
+  $conn_type = str(arg2);
+  $network = (int32) arg3;
+  $existing = (uint64) arg4;
+  printf("INBOUND conn from %s: id=%ld, type=%s, network=%d, total=%d\n", $addr, $id, $conn_type, $network, $existing);
+}
+
+usdt:./build/src/bitcoind:net:outbound_connection
+{
+  $id = (int64) arg0;
+  $addr = str(arg1);
+  $conn_type = str(arg2);
+  $network = (int32) arg3;
+  $existing = (uint64) arg4;
+  printf("OUTBOUND conn to %s: id=%ld, type=%s, network=%d, total=%d\n", $addr, $id, $conn_type, $network, $existing);
+}
+
+usdt:./build/src/bitcoind:net:closed_connection
+{
+  $id = (int64) arg0;
+  $addr = str(arg1);
+  $conn_type = str(arg2);
+  $network = (int32) arg3;
+  printf("CLOSED conn to %s: id=%ld, type=%s, network=%d, established=%ld\n", $addr, $id, $conn_type, $network, arg4);
+}
+
+usdt:./build/src/bitcoind:net:evicted_inbound_connection
+{
+  $id = (int64) arg0;
+  $addr = str(arg1);
+  $conn_type = str(arg2);
+  $network = (int32) arg3;
+  printf("EVICTED conn to %s: id=%ld, type=%s, network=%d, established=%ld\n", $addr, $id, $conn_type, $network, arg4);
+}
+
+usdt:./build/src/bitcoind:net:misbehaving_connection
+{
+  $id = (int64) arg0;
+  $message = str(arg1);
+  printf("MISBEHAVING conn id=%ld, message='%s'\n", $id, $message);
+}

--- a/contrib/tracing/log_raw_p2p_msgs.py
+++ b/contrib/tracing/log_raw_p2p_msgs.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+""" Demonstration of eBPF limitations and the effect on USDT with the
+    net:inbound_message and net:outbound_message tracepoints. """
+
+# This script shows a limitation of eBPF when data larger than 32kb is passed to
+# user-space. It uses BCC (https://github.com/iovisor/bcc) to load a sandboxed
+# eBPF program into the Linux kernel (root privileges are required). The eBPF
+# program attaches to two statically defined tracepoints. The tracepoint
+# 'net:inbound_message' is called when a new P2P message is received, and
+# 'net:outbound_message' is called on outbound P2P messages. The eBPF program
+# submits the P2P messages to this script via a BPF ring buffer. The submitted
+# messages are printed.
+
+# eBPF Limitations:
+#
+# Bitcoin P2P messages can be larger than 32kb (e.g. tx, block, ...). The eBPF
+# VM's stack is limited to 512 bytes, and we can't allocate more than about 32kb
+# for a P2P message in the eBPF VM. The message data is cut off when the message
+# is larger than MAX_MSG_DATA_LENGTH (see definition below). This can be detected
+# in user-space by comparing the data length to the message length variable. The
+# message is cut off when the data length is smaller than the message length.
+# A warning is included with the printed message data.
+#
+# Data is submitted to user-space (i.e. to this script) via a ring buffer. The
+# throughput of the ring buffer is limited. Each p2p_message is about 32kb in
+# size. In- or outbound messages submitted to the ring buffer in rapid
+# succession fill the ring buffer faster than it can be read. Some messages are
+# lost.
+#
+# BCC prints: "Possibly lost 2 samples" on lost messages.
+
+import sys
+from bcc import BPF, USDT
+
+# BCC: The C program to be compiled to an eBPF program (by BCC) and loaded into
+# a sandboxed Linux kernel VM.
+program = """
+#include <uapi/linux/ptrace.h>
+
+#define MIN(a,b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
+
+// Maximum possible allocation size
+// from include/linux/percpu.h in the Linux kernel
+#define PCPU_MIN_UNIT_SIZE (32 << 10)
+
+// Tor v3 addresses are 62 chars + 6 chars for the port (':12345').
+#define MAX_PEER_ADDR_LENGTH 62 + 6
+#define MAX_PEER_CONN_TYPE_LENGTH 20
+#define MAX_MSG_TYPE_LENGTH 20
+#define MAX_MSG_DATA_LENGTH PCPU_MIN_UNIT_SIZE - 200
+
+struct p2p_message
+{
+    u64     peer_id;
+    char    peer_addr[MAX_PEER_ADDR_LENGTH];
+    char    peer_conn_type[MAX_PEER_CONN_TYPE_LENGTH];
+    char    msg_type[MAX_MSG_TYPE_LENGTH];
+    u64     msg_size;
+    u8      msg[MAX_MSG_DATA_LENGTH];
+};
+
+// We can't store the p2p_message struct on the eBPF stack as it is limited to
+// 512 bytes and P2P message can be bigger than 512 bytes. However, we can use
+// an BPF-array with a length of 1 to allocate up to 32768 bytes (this is
+// defined by PCPU_MIN_UNIT_SIZE in include/linux/percpu.h in the Linux kernel).
+// Also see https://github.com/iovisor/bcc/issues/2306
+BPF_ARRAY(msg_arr, struct p2p_message, 1);
+
+// Two BPF perf buffers for pushing data (here P2P messages) to user-space.
+BPF_PERF_OUTPUT(inbound_messages);
+BPF_PERF_OUTPUT(outbound_messages);
+
+int trace_inbound_message(struct pt_regs *ctx) {
+    int idx = 0;
+    struct p2p_message *msg = msg_arr.lookup(&idx);
+
+    // lookup() does not return a NULL pointer. However, the BPF verifier
+    // requires an explicit check that that the `msg` pointer isn't a NULL
+    // pointer. See https://github.com/iovisor/bcc/issues/2595
+    if (msg == NULL) return 1;
+
+    bpf_usdt_readarg(1, ctx, &msg->peer_id);
+    bpf_usdt_readarg_p(2, ctx, &msg->peer_addr, MAX_PEER_ADDR_LENGTH);
+    bpf_usdt_readarg_p(3, ctx, &msg->peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
+    bpf_usdt_readarg_p(4, ctx, &msg->msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(5, ctx, &msg->msg_size);
+    bpf_usdt_readarg_p(6, ctx, &msg->msg, MIN(msg->msg_size, MAX_MSG_DATA_LENGTH));
+
+    inbound_messages.perf_submit(ctx, msg, sizeof(*msg));
+    return 0;
+};
+
+int trace_outbound_message(struct pt_regs *ctx) {
+    int idx = 0;
+    struct p2p_message *msg = msg_arr.lookup(&idx);
+
+    // lookup() does not return a NULL pointer. However, the BPF verifier
+    // requires an explicit check that that the `msg` pointer isn't a NULL
+    // pointer. See https://github.com/iovisor/bcc/issues/2595
+    if (msg == NULL) return 1;
+
+    bpf_usdt_readarg(1, ctx, &msg->peer_id);
+    bpf_usdt_readarg_p(2, ctx, &msg->peer_addr, MAX_PEER_ADDR_LENGTH);
+    bpf_usdt_readarg_p(3, ctx, &msg->peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
+    bpf_usdt_readarg_p(4, ctx, &msg->msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(5, ctx, &msg->msg_size);
+    bpf_usdt_readarg_p(6, ctx, &msg->msg,  MIN(msg->msg_size, MAX_MSG_DATA_LENGTH));
+
+    outbound_messages.perf_submit(ctx, msg, sizeof(*msg));
+    return 0;
+};
+"""
+
+
+def print_message(event, inbound):
+    print("{} {} msg '{}' from peer {} ({}, {}) with {} bytes: {}".format(
+
+              "Warning: incomplete message (only {} out of {} bytes)!".format(
+                  len(event.msg), event.msg_size) if len(event.msg) < event.msg_size else "",
+              "inbound" if inbound else "outbound",
+              event.msg_type.decode("utf-8"),
+              event.peer_id,
+              event.peer_conn_type.decode("utf-8"),
+              event.peer_addr.decode("utf-8"),
+              event.msg_size,
+              bytes(event.msg[:event.msg_size]).hex(),
+          )
+          )
+
+
+def main(pid):
+    print(f"Hooking into pocketcoind with pid {pid}")
+    pocketcoind_with_usdts = USDT(pid=int(pid))
+
+    # attaching the trace functions defined in the BPF program to the tracepoints
+    pocketcoind_with_usdts.enable_probe(
+        probe="inbound_message", fn_name="trace_inbound_message")
+    pocketcoind_with_usdts.enable_probe(
+        probe="outbound_message", fn_name="trace_outbound_message")
+    bpf = BPF(text=program, usdt_contexts=[pocketcoind_with_usdts])
+
+    # BCC: perf buffer handle function for inbound_messages
+    def handle_inbound(_, data, size):
+        """ Inbound message handler.
+
+        Called each time a message is submitted to the inbound_messages BPF table."""
+
+        event = bpf["inbound_messages"].event(data)
+        print_message(event, True)
+
+    # BCC: perf buffer handle function for outbound_messages
+
+    def handle_outbound(_, data, size):
+        """ Outbound message handler.
+
+        Called each time a message is submitted to the outbound_messages BPF table."""
+
+        event = bpf["outbound_messages"].event(data)
+        print_message(event, False)
+
+    # BCC: add handlers to the inbound and outbound perf buffers
+    bpf["inbound_messages"].open_perf_buffer(handle_inbound)
+    bpf["outbound_messages"].open_perf_buffer(handle_outbound)
+
+    print("Logging raw P2P messages.")
+    print("Messages larger that about 32kb will be cut off!")
+    print("Some messages might be lost!")
+    while True:
+        try:
+            bpf.perf_buffer_poll()
+        except KeyboardInterrupt:
+            exit()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("USAGE:", sys.argv[0], "<pid of pocketcoind>")
+        exit()
+    pid = sys.argv[1]
+    main(pid)

--- a/contrib/tracing/log_utxocache_flush.py
+++ b/contrib/tracing/log_utxocache_flush.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021-2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import sys
+import ctypes
+from bcc import BPF, USDT
+
+"""Example logging Pocketnet Core utxo set cache flushes utilizing
+    the utxocache:flush tracepoint."""
+
+# USAGE:  ./contrib/tracing/log_utxocache_flush.py path/to/pocketcoind
+
+# BCC: The C program to be compiled to an eBPF program (by BCC) and loaded into
+# a sandboxed Linux kernel VM.
+program = """
+# include <uapi/linux/ptrace.h>
+
+struct data_t
+{
+  u64 duration;
+  u32 mode;
+  u64 coins_count;
+  u64 coins_mem_usage;
+  bool is_flush_for_prune;
+};
+
+// BPF perf buffer to push the data to user space.
+BPF_PERF_OUTPUT(flush);
+
+int trace_flush(struct pt_regs *ctx) {
+  struct data_t data = {};
+  bpf_usdt_readarg(1, ctx, &data.duration);
+  bpf_usdt_readarg(2, ctx, &data.mode);
+  bpf_usdt_readarg(3, ctx, &data.coins_count);
+  bpf_usdt_readarg(4, ctx, &data.coins_mem_usage);
+  bpf_usdt_readarg(5, ctx, &data.is_flush_for_prune);
+  flush.perf_submit(ctx, &data, sizeof(data));
+  return 0;
+}
+"""
+
+FLUSH_MODES = [
+    'NONE',
+    'IF_NEEDED',
+    'PERIODIC',
+    'ALWAYS'
+]
+
+
+class Data(ctypes.Structure):
+    # define output data structure corresponding to struct data_t
+    _fields_ = [
+        ("duration", ctypes.c_uint64),
+        ("mode", ctypes.c_uint32),
+        ("coins_count", ctypes.c_uint64),
+        ("coins_mem_usage", ctypes.c_uint64),
+        ("is_flush_for_prune", ctypes.c_bool)
+    ]
+
+
+def print_event(event):
+    print("%-15d %-10s %-15d %-15s %-8s" % (
+        event.duration,
+        FLUSH_MODES[event.mode],
+        event.coins_count,
+        "%.2f kB" % (event.coins_mem_usage/1000),
+        event.is_flush_for_prune
+    ))
+
+
+def main(pid):
+    print(f"Hooking into pocketcoind with pid {pid}")
+    pocketcoind_with_usdts = USDT(pid=int(pid))
+
+    # attaching the trace functions defined in the BPF program
+    # to the tracepoints
+    pocketcoind_with_usdts.enable_probe(
+        probe="flush", fn_name="trace_flush")
+    b = BPF(text=program, usdt_contexts=[pocketcoind_with_usdts])
+
+    def handle_flush(_, data, size):
+        """ Coins Flush handler.
+          Called each time coin caches and indexes are flushed."""
+        event = ctypes.cast(data, ctypes.POINTER(Data)).contents
+        print_event(event)
+
+    b["flush"].open_perf_buffer(handle_flush)
+    print("Logging utxocache flushes. Ctrl-C to end...")
+    print("%-15s %-10s %-15s %-15s %-8s" % ("Duration (µs)", "Mode",
+                                            "Coins Count", "Memory Usage",
+                                            "Flush for Prune"))
+
+    while True:
+        try:
+            b.perf_buffer_poll()
+        except KeyboardInterrupt:
+            exit(0)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("USAGE: ", sys.argv[0], "<pid of pocketcoind>")
+        exit(1)
+
+    pid = sys.argv[1]
+    main(pid)

--- a/contrib/tracing/mempool_monitor.py
+++ b/contrib/tracing/mempool_monitor.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+""" Example logging Pocketnet Core mempool events using the mempool:added,
+    mempool:removed, mempool:replaced, and mempool:rejected tracepoints. """
+
+import curses
+import sys
+from datetime import datetime, timezone
+
+from bcc import BPF, USDT
+
+# BCC: The C program to be compiled to an eBPF program (by BCC) and loaded into
+# a sandboxed Linux kernel VM.
+PROGRAM = """
+# include <uapi/linux/ptrace.h>
+
+// The longest rejection reason is 118 chars and is generated in case of SCRIPT_ERR_EVAL_FALSE by
+// strprintf("mandatory-script-verify-flag-failed (%s)", ScriptErrorString(check.GetScriptError()))
+#define MAX_REJECT_REASON_LENGTH        118
+// The longest string returned by RemovalReasonToString() is 'sizelimit'
+#define MAX_REMOVAL_REASON_LENGTH       9
+#define HASH_LENGTH                     32
+
+struct added_event
+{
+  u8    hash[HASH_LENGTH];
+  s32   vsize;
+  s64   fee;
+};
+
+struct removed_event
+{
+  u8    hash[HASH_LENGTH];
+  char  reason[MAX_REMOVAL_REASON_LENGTH];
+  s32   vsize;
+  s64   fee;
+  u64   entry_time;
+};
+
+struct rejected_event
+{
+  u8    hash[HASH_LENGTH];
+  char  reason[MAX_REJECT_REASON_LENGTH];
+};
+
+struct replaced_event
+{
+  u8    replaced_hash[HASH_LENGTH];
+  s32   replaced_vsize;
+  s64   replaced_fee;
+  u64   replaced_entry_time;
+  u8    replacement_hash[HASH_LENGTH];
+  s32   replacement_vsize;
+  s64   replacement_fee;
+};
+
+// BPF perf buffer to push the data to user space.
+BPF_PERF_OUTPUT(added_events);
+BPF_PERF_OUTPUT(removed_events);
+BPF_PERF_OUTPUT(rejected_events);
+BPF_PERF_OUTPUT(replaced_events);
+
+int trace_added(struct pt_regs *ctx) {
+  struct added_event added = {};
+
+  bpf_usdt_readarg_p(1, ctx, &added.hash, HASH_LENGTH);
+  bpf_usdt_readarg(2, ctx, &added.vsize);
+  bpf_usdt_readarg(3, ctx, &added.fee);
+
+  added_events.perf_submit(ctx, &added, sizeof(added));
+  return 0;
+}
+
+int trace_removed(struct pt_regs *ctx) {
+  struct removed_event removed = {};
+
+  bpf_usdt_readarg_p(1, ctx, &removed.hash, HASH_LENGTH);
+  bpf_usdt_readarg_p(2, ctx, &removed.reason, MAX_REMOVAL_REASON_LENGTH);
+  bpf_usdt_readarg(3, ctx, &removed.vsize);
+  bpf_usdt_readarg(4, ctx, &removed.fee);
+  bpf_usdt_readarg(5, ctx, &removed.entry_time);
+
+  removed_events.perf_submit(ctx, &removed, sizeof(removed));
+  return 0;
+}
+
+int trace_rejected(struct pt_regs *ctx) {
+  struct rejected_event rejected = {};
+
+  bpf_usdt_readarg_p(1, ctx, &rejected.hash, HASH_LENGTH);
+  bpf_usdt_readarg_p(2, ctx, &rejected.reason, MAX_REJECT_REASON_LENGTH);
+
+  rejected_events.perf_submit(ctx, &rejected, sizeof(rejected));
+  return 0;
+}
+
+int trace_replaced(struct pt_regs *ctx) {
+  struct replaced_event replaced = {};
+
+  bpf_usdt_readarg_p(1, ctx, &replaced.replaced_hash, HASH_LENGTH);
+  bpf_usdt_readarg(2, ctx, &replaced.replaced_vsize);
+  bpf_usdt_readarg(3, ctx, &replaced.replaced_fee);
+  bpf_usdt_readarg(4, ctx, &replaced.replaced_entry_time);
+  bpf_usdt_readarg_p(5, ctx, &replaced.replacement_hash, HASH_LENGTH);
+  bpf_usdt_readarg(6, ctx, &replaced.replacement_vsize);
+  bpf_usdt_readarg(7, ctx, &replaced.replacement_fee);
+
+  replaced_events.perf_submit(ctx, &replaced, sizeof(replaced));
+  return 0;
+}
+"""
+
+
+def main(pid):
+    print(f"Hooking into pocketcoind with pid {pid}")
+    pocketcoind_with_usdts = USDT(pid=int(pid))
+
+    # attaching the trace functions defined in the BPF program
+    # to the tracepoints
+    pocketcoind_with_usdts.enable_probe(probe="mempool:added", fn_name="trace_added")
+    pocketcoind_with_usdts.enable_probe(probe="mempool:removed", fn_name="trace_removed")
+    pocketcoind_with_usdts.enable_probe(probe="mempool:replaced", fn_name="trace_replaced")
+    pocketcoind_with_usdts.enable_probe(probe="mempool:rejected", fn_name="trace_rejected")
+    bpf = BPF(text=PROGRAM, usdt_contexts=[pocketcoind_with_usdts])
+
+    events = []
+
+    def get_timestamp():
+        return datetime.now(timezone.utc)
+
+    def handle_added(_, data, size):
+        event = bpf["added_events"].event(data)
+        events.append((get_timestamp(), "added", event))
+
+    def handle_removed(_, data, size):
+        event = bpf["removed_events"].event(data)
+        events.append((get_timestamp(), "removed", event))
+
+    def handle_rejected(_, data, size):
+        event = bpf["rejected_events"].event(data)
+        events.append((get_timestamp(), "rejected", event))
+
+    def handle_replaced(_, data, size):
+        event = bpf["replaced_events"].event(data)
+        events.append((get_timestamp(), "replaced", event))
+
+    bpf["added_events"].open_perf_buffer(handle_added)
+    # By default, open_perf_buffer uses eight pages for a buffer, making for a total
+    # buffer size of 32k on most machines. In practice, this size is insufficient:
+    # Each `mempool:removed` event takes up 57 bytes in the buffer (32 bytes for txid,
+    # 9 bytes for removal reason, and 8 bytes each for vsize and fee). Full blocks
+    # contain around 2k transactions, requiring a buffer size of around 114kB. To cover
+    # this amount, 32 4k pages are required.
+    bpf["removed_events"].open_perf_buffer(handle_removed, page_cnt=32)
+    bpf["rejected_events"].open_perf_buffer(handle_rejected)
+    bpf["replaced_events"].open_perf_buffer(handle_replaced)
+
+    curses.wrapper(loop, bpf, events)
+
+
+def loop(screen, bpf, events):
+    dashboard = Dashboard(screen)
+    while True:
+        try:
+            bpf.perf_buffer_poll(timeout=50)
+            dashboard.render(events)
+        except KeyboardInterrupt:
+            exit()
+
+
+class Dashboard:
+    """Visualization of mempool state using ncurses."""
+
+    INFO_WIN_HEIGHT = 2
+    EVENT_WIN_HEIGHT = 7
+
+    def __init__(self, screen):
+        screen.nodelay(True)
+        curses.curs_set(False)
+        self._screen = screen
+        self._time_started = datetime.now(timezone.utc)
+        self._timestamps = {"added": [], "removed": [], "rejected": [], "replaced": []}
+        self._event_history = {"added": 0, "removed": 0, "rejected": 0, "replaced": 0}
+        self._init_windows()
+
+    def _init_windows(self):
+        """Initialize all windows."""
+        self._init_info_win()
+        self._init_event_count_win()
+        self._init_event_rate_win()
+        self._init_event_log_win()
+
+    @staticmethod
+    def create_win(x, y, height, width, title=None):
+        """Helper function to create generic windows and decorate them with box and title if requested."""
+        win = curses.newwin(height, width, x, y)
+        if title:
+            win.box()
+            win.addstr(0, 2, title, curses.A_BOLD)
+        return win
+
+    def _init_info_win(self):
+        """Create and populate the info window."""
+        self._info_win = Dashboard.create_win(
+            x=0, y=1, height=Dashboard.INFO_WIN_HEIGHT, width=22
+        )
+        self._info_win.addstr(0, 0, "Mempool Monitor", curses.A_REVERSE)
+        self._info_win.addstr(1, 0, "Press CTRL-C to stop.", curses.A_NORMAL)
+        self._info_win.refresh()
+
+    def _init_event_count_win(self):
+        """Create and populate the event count window."""
+        self._event_count_win = Dashboard.create_win(
+            x=3, y=1, height=Dashboard.EVENT_WIN_HEIGHT, width=37, title="Event count"
+        )
+        header = " {:<8} {:>8} {:>7} {:>7} "
+        self._event_count_win.addstr(
+            1, 1, header.format("Event", "total", "1 min", "10 min"), curses.A_UNDERLINE
+        )
+        self._event_count_win.refresh()
+
+    def _init_event_rate_win(self):
+        """Create and populate the event rate window."""
+        self._event_rate_win = Dashboard.create_win(
+            x=3, y=40, height=Dashboard.EVENT_WIN_HEIGHT, width=42, title="Event rate"
+        )
+        header = " {:<8} {:>9} {:>9} {:>9} "
+        self._event_rate_win.addstr(
+            1, 1, header.format("Event", "total", "1 min", "10 min"), curses.A_UNDERLINE
+        )
+        self._event_rate_win.refresh()
+
+    def _init_event_log_win(self):
+        """Create windows showing event log. This comprises a dummy boxed window and an
+        inset window so line breaks don't overwrite box."""
+        # dummy boxed window
+        num_rows, num_cols = self._screen.getmaxyx()
+        space_above = Dashboard.INFO_WIN_HEIGHT + 1 + Dashboard.EVENT_WIN_HEIGHT + 1
+        box_win_height = num_rows - space_above
+        box_win_width = num_cols - 2
+        win_box = Dashboard.create_win(
+            x=space_above,
+            y=1,
+            height=box_win_height,
+            width=box_win_width,
+            title="Event log",
+        )
+        # actual logging window
+        log_lines = box_win_height - 2  # top and bottom box lines
+        log_line_len = box_win_width - 2 - 1  # box lines and left padding
+        win = win_box.derwin(log_lines, log_line_len, 1, 2)
+        win.idlok(True)
+        win.scrollok(True)
+        win_box.refresh()
+        win.refresh()
+        self._event_log_win_box = win_box
+        self._event_log_win = win
+
+    def calculate_metrics(self, events):
+        """Calculate count and rate metrics."""
+        count, rate = {}, {}
+        for event_ts, event_type, event_data in events:
+            self._timestamps[event_type].append(event_ts)
+        for event_type, ts in self._timestamps.items():
+            # remove timestamps older than ten minutes but keep track of their
+            # count for the 'total' metric
+            #
+            self._event_history[event_type] += len(
+                [t for t in ts if Dashboard.timestamp_age(t) >= 600]
+            )
+            ts = [t for t in ts if Dashboard.timestamp_age(t) < 600]
+            self._timestamps[event_type] = ts
+            # count metric
+            count_1m = len([t for t in ts if Dashboard.timestamp_age(t) < 60])
+            count_10m = len(ts)
+            count_total = self._event_history[event_type] + len(ts)
+            count[event_type] = (count_total, count_1m, count_10m)
+            # rate metric
+            runtime = Dashboard.timestamp_age(self._time_started)
+            rate_1m = count_1m / min(60, runtime)
+            rate_10m = count_10m / min(600, runtime)
+            rate_total = count_total / runtime
+            rate[event_type] = (rate_total, rate_1m, rate_10m)
+        return count, rate
+
+    def _update_event_count(self, count):
+        """Update the event count window."""
+        w = self._event_count_win
+        row_format = " {:<8} {:>6}tx {:>5}tx {:>5}tx "
+        for line, metric in enumerate(["added", "removed", "replaced", "rejected"]):
+            w.addstr(2 + line, 1, row_format.format(metric, *count[metric]))
+        w.refresh()
+
+    def _update_event_rate(self, rate):
+        """Update the event rate window."""
+        w = self._event_rate_win
+        row_format = " {:<8} {:>5.1f}tx/s {:>5.1f}tx/s {:>5.1f}tx/s "
+        for line, metric in enumerate(["added", "removed", "replaced", "rejected"]):
+            w.addstr(2 + line, 1, row_format.format(metric, *rate[metric]))
+        w.refresh()
+
+    def _update_event_log(self, events):
+        """Update the event log window."""
+        w = self._event_log_win
+        for event in events:
+            w.addstr(Dashboard.parse_event(event) + "\n")
+        w.refresh()
+
+    def render(self, events):
+        """Render the dashboard."""
+        count, rate = self.calculate_metrics(events)
+        self._update_event_count(count)
+        self._update_event_rate(rate)
+        self._update_event_log(events)
+        events.clear()
+
+    @staticmethod
+    def parse_event(event):
+        """Converts events into human-readable messages"""
+
+        ts_dt, type_, data = event
+        ts = ts_dt.strftime("%H:%M:%SZ")
+        if type_ == "added":
+            return (
+                f"{ts} added {bytes(data.hash)[::-1].hex()}"
+                f" with feerate {data.fee/data.vsize:.2f} sat/vB"
+                f" ({data.fee} sat, {data.vsize} vbytes)"
+            )
+
+        if type_ == "removed":
+            return (
+                f"{ts} removed {bytes(data.hash)[::-1].hex()}"
+                f" with feerate {data.fee/data.vsize:.2f} sat/vB"
+                f" ({data.fee} sat, {data.vsize} vbytes)"
+                f" received {ts_dt.timestamp()-data.entry_time:.1f} seconds ago"
+                f": {data.reason.decode('UTF-8')}"
+            )
+
+        if type_ == "rejected":
+            return (
+                f"{ts} rejected {bytes(data.hash)[::-1].hex()}"
+                f": {data.reason.decode('UTF-8')}"
+            )
+
+        if type_ == "replaced":
+            return (
+                f"{ts} replaced {bytes(data.replaced_hash)[::-1].hex()}"
+                f" with feerate {data.replaced_fee/data.replaced_vsize:.2f} sat/vB"
+                f" received {ts_dt.timestamp()-data.replaced_entry_time:.1f} seconds ago"
+                f" ({data.replaced_fee} sat, {data.replaced_vsize} vbytes)"
+                f" with {bytes(data.replacement_hash)[::-1].hex()}"
+                f" with feerate {data.replacement_fee/data.replacement_vsize:.2f} sat/vB"
+                f" ({data.replacement_fee} sat, {data.replacement_vsize} vbytes)"
+            )
+
+        raise NotImplementedError("Unsupported event type: {type_}")
+
+    @staticmethod
+    def timestamp_age(timestamp):
+        """Return age of timestamp in seconds."""
+        return (datetime.now(timezone.utc) - timestamp).total_seconds()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("USAGE: ", sys.argv[0], "<pid of pocketcoind>")
+        exit(1)
+
+    pid = sys.argv[1]
+    main(pid)

--- a/contrib/tracing/p2p_monitor.py
+++ b/contrib/tracing/p2p_monitor.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+""" Interactive pocketcoind P2P network traffic monitor utilizing USDT and the
+    net:inbound_message and net:outbound_message tracepoints. """
+
+# This script demonstrates what USDT for Pocketnet Core can enable. It uses BCC
+# (https://github.com/iovisor/bcc) to load a sandboxed eBPF program into the
+# Linux kernel (root privileges are required). The eBPF program attaches to two
+# statically defined tracepoints. The tracepoint 'net:inbound_message' is called
+# when a new P2P message is received, and 'net:outbound_message' is called on
+# outbound P2P messages. The eBPF program submits the P2P messages to
+# this script via a BPF ring buffer.
+
+import curses
+import os
+import sys
+from curses import wrapper, panel
+from bcc import BPF, USDT
+
+# BCC: The C program to be compiled to an eBPF program (by BCC) and loaded into
+# a sandboxed Linux kernel VM.
+program = """
+#include <uapi/linux/ptrace.h>
+
+// Tor v3 addresses are 62 chars + 6 chars for the port (':12345').
+// I2P addresses are 60 chars + 6 chars for the port (':12345').
+#define MAX_PEER_ADDR_LENGTH 62 + 6
+#define MAX_PEER_CONN_TYPE_LENGTH 20
+#define MAX_MSG_TYPE_LENGTH 20
+
+struct p2p_message
+{
+    u64     peer_id;
+    char    peer_addr[MAX_PEER_ADDR_LENGTH];
+    char    peer_conn_type[MAX_PEER_CONN_TYPE_LENGTH];
+    char    msg_type[MAX_MSG_TYPE_LENGTH];
+    u64     msg_size;
+};
+
+
+// Two BPF perf buffers for pushing data (here P2P messages) to user space.
+BPF_PERF_OUTPUT(inbound_messages);
+BPF_PERF_OUTPUT(outbound_messages);
+
+int trace_inbound_message(struct pt_regs *ctx) {
+    struct p2p_message msg = {};
+
+    bpf_usdt_readarg(1, ctx, &msg.peer_id);
+    bpf_usdt_readarg_p(2, ctx, &msg.peer_addr, MAX_PEER_ADDR_LENGTH);
+    bpf_usdt_readarg_p(3, ctx, &msg.peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
+    bpf_usdt_readarg_p(4, ctx, &msg.msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(5, ctx, &msg.msg_size);
+
+    inbound_messages.perf_submit(ctx, &msg, sizeof(msg));
+    return 0;
+};
+
+int trace_outbound_message(struct pt_regs *ctx) {
+    struct p2p_message msg = {};
+
+    bpf_usdt_readarg(1, ctx, &msg.peer_id);
+    bpf_usdt_readarg_p(2, ctx, &msg.peer_addr, MAX_PEER_ADDR_LENGTH);
+    bpf_usdt_readarg_p(3, ctx, &msg.peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
+    bpf_usdt_readarg_p(4, ctx, &msg.msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(5, ctx, &msg.msg_size);
+
+    outbound_messages.perf_submit(ctx, &msg, sizeof(msg));
+    return 0;
+};
+"""
+
+
+class Message:
+    """ A P2P network message. """
+    msg_type = ""
+    size = 0
+    data = bytes()
+    inbound = False
+
+    def __init__(self, msg_type, size, inbound):
+        self.msg_type = msg_type
+        self.size = size
+        self.inbound = inbound
+
+
+class Peer:
+    """ A P2P network peer. """
+    id = 0
+    address = ""
+    connection_type = ""
+    last_messages = list()
+
+    total_inbound_msgs = 0
+    total_inbound_bytes = 0
+    total_outbound_msgs = 0
+    total_outbound_bytes = 0
+
+    def __init__(self, id, address, connection_type):
+        self.id = id
+        self.address = address
+        self.connection_type = connection_type
+        self.last_messages = list()
+
+    def add_message(self, message):
+        self.last_messages.append(message)
+        if len(self.last_messages) > 25:
+            self.last_messages.pop(0)
+        if message.inbound:
+            self.total_inbound_bytes += message.size
+            self.total_inbound_msgs += 1
+        else:
+            self.total_outbound_bytes += message.size
+            self.total_outbound_msgs += 1
+
+
+def main(pid):
+    peers = dict()
+    print(f"Hooking into pocketcoind with pid {pid}")
+    pocketcoind_with_usdts = USDT(pid=int(pid))
+
+    # attaching the trace functions defined in the BPF program to the tracepoints
+    pocketcoind_with_usdts.enable_probe(
+        probe="inbound_message", fn_name="trace_inbound_message")
+    pocketcoind_with_usdts.enable_probe(
+        probe="outbound_message", fn_name="trace_outbound_message")
+    bpf = BPF(text=program, usdt_contexts=[pocketcoind_with_usdts])
+
+    # BCC: perf buffer handle function for inbound_messages
+    def handle_inbound(_, data, size):
+        """ Inbound message handler.
+
+        Called each time a message is submitted to the inbound_messages BPF table."""
+        event = bpf["inbound_messages"].event(data)
+        if event.peer_id not in peers:
+            peer = Peer(event.peer_id, event.peer_addr.decode(
+                "utf-8"), event.peer_conn_type.decode("utf-8"))
+            peers[peer.id] = peer
+        peers[event.peer_id].add_message(
+            Message(event.msg_type.decode("utf-8"), event.msg_size, True))
+
+    # BCC: perf buffer handle function for outbound_messages
+    def handle_outbound(_, data, size):
+        """ Outbound message handler.
+
+        Called each time a message is submitted to the outbound_messages BPF table."""
+        event = bpf["outbound_messages"].event(data)
+        if event.peer_id not in peers:
+            peer = Peer(event.peer_id, event.peer_addr.decode(
+                "utf-8"), event.peer_conn_type.decode("utf-8"))
+            peers[peer.id] = peer
+        peers[event.peer_id].add_message(
+            Message(event.msg_type.decode("utf-8"), event.msg_size, False))
+
+    # BCC: add handlers to the inbound and outbound perf buffers
+    bpf["inbound_messages"].open_perf_buffer(handle_inbound)
+    bpf["outbound_messages"].open_perf_buffer(handle_outbound)
+
+    wrapper(loop, bpf, peers)
+
+
+def loop(screen, bpf, peers):
+    screen.nodelay(1)
+    cur_list_pos = 0
+    win = curses.newwin(30, 70, 2, 7)
+    win.erase()
+    win.border(ord("|"), ord("|"), ord("-"), ord("-"),
+               ord("-"), ord("-"), ord("-"), ord("-"))
+    info_panel = panel.new_panel(win)
+    info_panel.hide()
+
+    ROWS_AVALIABLE_FOR_LIST = curses.LINES - 5
+    scroll = 0
+
+    while True:
+        try:
+            # BCC: poll the perf buffers for new events or timeout after 50ms
+            bpf.perf_buffer_poll(timeout=50)
+
+            ch = screen.getch()
+            if (ch == curses.KEY_DOWN or ch == ord("j")) and cur_list_pos < len(
+                    peers.keys()) -1 and info_panel.hidden():
+                cur_list_pos += 1
+                if cur_list_pos >= ROWS_AVALIABLE_FOR_LIST:
+                    scroll += 1
+            if (ch == curses.KEY_UP or ch == ord("k")) and cur_list_pos > 0 and info_panel.hidden():
+                cur_list_pos -= 1
+                if scroll > 0:
+                    scroll -= 1
+            if ch == ord('\n') or ch == ord(' '):
+                if info_panel.hidden():
+                    info_panel.show()
+                else:
+                    info_panel.hide()
+            screen.erase()
+            render(screen, peers, cur_list_pos, scroll, ROWS_AVALIABLE_FOR_LIST, info_panel)
+            curses.panel.update_panels()
+            screen.refresh()
+        except KeyboardInterrupt:
+            exit()
+
+
+def render(screen, peers, cur_list_pos, scroll, ROWS_AVALIABLE_FOR_LIST, info_panel):
+    """ renders the list of peers and details panel
+
+    This code is unrelated to USDT, BCC and BPF.
+    """
+    header_format = "%6s  %-20s  %-20s  %-22s  %-67s"
+    row_format = "%6s  %-5d %9d byte  %-5d %9d byte  %-22s  %-67s"
+
+    screen.addstr(0, 1, (" P2P Message Monitor "), curses.A_REVERSE)
+    screen.addstr(
+        1, 0, (" Navigate with UP/DOWN or J/K and select a peer with ENTER or SPACE to see individual P2P messages"), curses.A_NORMAL)
+    screen.addstr(3, 0,
+                  header_format % ("PEER", "OUTBOUND", "INBOUND", "TYPE", "ADDR"), curses.A_BOLD | curses.A_UNDERLINE)
+    peer_list = sorted(peers.keys())[scroll:ROWS_AVALIABLE_FOR_LIST+scroll]
+    for i, peer_id in enumerate(peer_list):
+        peer = peers[peer_id]
+        screen.addstr(i + 4, 0,
+                      row_format % (peer.id, peer.total_outbound_msgs, peer.total_outbound_bytes,
+                                    peer.total_inbound_msgs, peer.total_inbound_bytes,
+                                    peer.connection_type, peer.address),
+                      curses.A_REVERSE if i + scroll == cur_list_pos else curses.A_NORMAL)
+        if i + scroll == cur_list_pos:
+            info_window = info_panel.window()
+            info_window.erase()
+            info_window.border(
+                ord("|"), ord("|"), ord("-"), ord("-"),
+                ord("-"), ord("-"), ord("-"), ord("-"))
+
+            info_window.addstr(
+                1, 1, f"PEER {peer.id} ({peer.address})".center(68), curses.A_REVERSE | curses.A_BOLD)
+            info_window.addstr(
+                2, 1, f" OUR NODE{peer.connection_type:^54}PEER ",
+                curses.A_BOLD)
+            for i, msg in enumerate(peer.last_messages):
+                if msg.inbound:
+                    info_window.addstr(
+                        i + 3, 1, "%68s" %
+                        (f"<--- {msg.msg_type} ({msg.size} bytes) "), curses.A_NORMAL)
+                else:
+                    info_window.addstr(
+                        i + 3, 1, " %s (%d byte) --->" %
+                        (msg.msg_type, msg.size), curses.A_NORMAL)
+
+
+def running_as_root():
+    return os.getuid() == 0
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("USAGE:", sys.argv[0], "<pid of pocketcoind>")
+        exit()
+    if not running_as_root():
+        print("You might not have the privileges required to hook into the tracepoints!")
+    pid = sys.argv[1]
+    main(pid)

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -48,6 +48,7 @@ Optional dependencies:
  libqrencode | QR codes in GUI  | Optional for generating QR codes (only needed when GUI enabled)
  univalue    | Utility          | JSON parsing and encoding (bundled version will be used unless --with-system-univalue passed to configure)
  libzmq3     | ZMQ notification | Optional, allows generating ZMQ notifications (requires ZMQ version >= 4.0.0)
+ systemtap   | Tracing (USDT)   | Optional, statically defined tracepoints
 
 For the versions used, see [dependencies.md](dependencies.md)
 
@@ -95,6 +96,10 @@ ZMQ dependencies (provides ZMQ API):
 
     sudo apt-get install libzmq3-dev
 
+User-Space, Statically Defined Tracing (USDT) dependencies:
+
+    sudo apt install systemtap-sdt-dev
+
 #### Dependencies for the GUI
 
 If you want to build pocketcoin-qt, make sure that the required packages for Qt development
@@ -125,13 +130,27 @@ Optional:
 
     sudo dnf install miniupnpc-devel
 
+User-Space, Statically Defined Tracing (USDT) dependencies:
+
+    sudo dnf install systemtap
+
+
+GUI dependencies:
+
+If you want to build pocketcoin-qt, make sure that the required packages for Qt development
+are installed. Qt 5 is necessary to build the GUI.
+To build without GUI pass `--without-gui`.
+
 To build with Qt 5 you need the following:
 
-    sudo dnf install qt5-qttools-devel qt5-qtbase-devel protobuf-devel
+    sudo dnf install qt5-qttools-devel qt5-qtbase-devel
 
 libqrencode (optional) can be installed with:
 
     sudo dnf install qrencode-devel
+
+Once these are installed, they will be found by configure and a pocketcoin-qt executable will be
+built by default.
 
 Notes
 -----

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -1,7 +1,7 @@
 Dependencies
 ============
 
-These are the dependencies currently used by Pocketcoin Core. You can find instructions for installing them in the `build-*.md` file for your platform.
+These are the dependencies currently used by Pocketnet Core. You can find instructions for installing them in the `build-*.md` file for your platform.
 
 | Dependency | Minimum required |
 | --- | --- |
@@ -19,8 +19,9 @@ These are the dependencies currently used by Pocketcoin Core. You can find instr
 | libevent | [2.1.8-stable](https://github.com/libevent/libevent/releases) | 2.0.22 | No |  |  |
 | Clang |  | [3.3+](https://llvm.org/releases/download.html) (C++11 support) |  |  |  |
 | OpenSSL | [1.1.1w](https://github.com/pocketnetteam/pocketnet.core/pull/664) |  | Yes |  |  |
-| Qt | [5.9.6](https://download.qt.io/official_releases/qt/) | 5.x | No |  |  |
+| Qt | [5.15.14](https://download.qt.io/official_releases/qt/) | 5.9.8 | No |  |  |
 | XCB |  |  |  |  | [Yes](https://github.com/pocketcoin/pocketcoin/blob/master/depends/packages/qt.mk#L87) (Linux only) |
+| systemtap ([tracing](tracing.md))|  |  |  |  | |
 | xkbcommon |  |  |  |  | [Yes](https://github.com/pocketcoin/pocketcoin/blob/master/depends/packages/qt.mk#L86) (Linux only) |
 | Expat | [2.2.5](https://libexpat.github.io/) |  | No | Yes |  |
 | fontconfig | [2.12.1](https://www.freedesktop.org/software/fontconfig/release/) |  | No | Yes |  |
@@ -35,3 +36,23 @@ These are the dependencies currently used by Pocketcoin Core. You can find instr
 | MiniUPnPc | [2.0.20180203](http://miniupnp.free.fr/files) |  | No |  |  |
 | ZeroMQ | [4.2.5](https://github.com/zeromq/libzmq/releases) | 4.0.0 | No |  |  |
 | zlib | [1.2.11](https://zlib.net/) |  |  |  | No |
+
+<a name="note1">Note \*</a> : When compiling with `-stdlib=libc++`, the minimum supported libc++ version is 7.0.
+
+Controlling dependencies
+------------------------
+
+Some dependencies are not needed in all configurations. The following are some factors that affect the dependency list.
+#### Options passed to `./configure`
+* MiniUPnPc is not needed with `--without-miniupnpc`.
+* libnatpmp is not needed with `--without-natpmp`.
+* Berkeley DB is not needed with `--disable-wallet` or `--without-bdb`.
+* SQLite is not needed with `--disable-wallet` or `--without-sqlite`.
+* Qt is not needed with `--without-gui`.
+* If the qrencode dependency is absent, QR support won't be added. To force an error when that happens, pass `--with-qrencode`.
+* If the systemtap dependency is absent, USDT support won't compiled in.
+* ZeroMQ is needed only with the `--with-zmq` option.
+
+#### Other
+* librsvg is only needed if you need to run `make deploy` on (cross-compilation to) macOS.
+* Not-Qt-bundled zlib is required to build the [DMG tool](../contrib/macdeploy/README.md#deterministic-macos-dmg-notes) from the libdmg-hfsplus project.

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -11,7 +11,7 @@ eBPF and USDT Overview
 ======================
 
                 ┌──────────────────┐            ┌──────────────┐
-                │ tracing script   │            │ pocketcoind     │
+                │ tracing script   │            │ pocketcoind  │
                 │==================│      2.    │==============│
                 │  eBPF  │ tracing │      hooks │              │
                 │  code  │ logic   │      into┌─┤►tracepoint 1─┼───┐ 3.

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -55,6 +55,9 @@ The currently available tracepoints are listed here.
 
 ### Context `net`
 
+[^address-length]: An Onion v3 address with a `:` and a five digit port has 68
+  chars. However, addresses of peers added with host names might be longer.
+
 #### Tracepoint `net:inbound_message`
 
 Is called when a message is received from a peer over the P2P network. Passes
@@ -62,7 +65,7 @@ information about our peer, the connection and the message as arguments.
 
 Arguments passed:
 1. Peer ID as `int64`
-2. Peer Address and Port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (max. length 68 characters)
+2. Peer Address and Port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (normally up to 68 characters[^address-length])
 3. Connection Type (inbound, feeler, outbound-full-relay, ...) as `pointer to C-style String` (max. length 20 characters)
 4. Message Type (inv, ping, getdata, addrv2, ...) as `pointer to C-style String` (max. length 20 characters)
 5. Message Size in bytes as `uint64`
@@ -81,7 +84,7 @@ information about our peer, the connection and the message as arguments.
 
 Arguments passed:
 1. Peer ID as `int64`
-2. Peer Address and Port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (max. length 68 characters)
+2. Peer Address and Port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (normally up to 68 characters[^address-length])
 3. Connection Type (inbound, feeler, outbound-full-relay, ...) as `pointer to C-style String` (max. length 20 characters)
 4. Message Type (inv, ping, getdata, addrv2, ...) as `pointer to C-style String` (max. length 20 characters)
 5. Message Size in bytes as `uint64`
@@ -92,6 +95,62 @@ limitations in the eBPF kernel VM it might not be possible to pass the message
 to user-space in full. Messages longer than a 32kb might be cut off. This can
 be detected in tracing scripts by comparing the message size to the length of
 the passed message.
+
+#### Tracepoint `net:inbound_connection`
+
+Is called when a new inbound connection is opened to us. Passes information about
+the peer and the number of inbound connections including the newly opened connection.
+
+Arguments passed:
+1. Peer ID as `int64`
+2. Peer address and port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (normally up to 68 characters[^address-length])
+3. Connection Type (inbound, feeler, outbound-full-relay, ...) as `pointer to C-style String` (max. length 20 characters)
+4. Network the peer connects from as `uint32` (1 = IPv4, 2 = IPv6, 3 = Onion, 4 = I2P, 5 = CJDNS). See `Network` enum in `netaddress.h`.
+5. Number of existing inbound connections as `uint64` including the newly opened inbound connection.
+
+#### Tracepoint `net:outbound_connection`
+
+Is called when a new outbound connection is opened by us. Passes information about
+the peer and the number of outbound connections including the newly opened connection.
+
+Arguments passed:
+1. Peer ID as `int64`
+2. Peer address and port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (normally up to 68 characters[^address-length])
+3. Connection Type (inbound, feeler, outbound-full-relay, ...) as `pointer to C-style String` (max. length 20 characters)
+4. Network of the peer as `uint32` (1 = IPv4, 2 = IPv6, 3 = Onion, 4 = I2P, 5 = CJDNS). See `Network` enum in `netaddress.h`.
+5. Number of existing outbound connections as `uint64` including the newly opened outbound connection.
+
+#### Tracepoint `net:evicted_inbound_connection`
+
+Is called when a inbound connection is evicted by us. Passes information about the evicted peer and the time at connection establishment.
+
+Arguments passed:
+1. Peer ID as `int64`
+2. Peer address and port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (normally up to 68 characters[^address-length])
+3. Connection Type (inbound, feeler, outbound-full-relay, ...) as `pointer to C-style String` (max. length 20 characters)
+4. Network the peer connects from as `uint32` (1 = IPv4, 2 = IPv6, 3 = Onion, 4 = I2P, 5 = CJDNS). See `Network` enum in `netaddress.h`.
+5. Connection established UNIX epoch timestamp in seconds as `uint64`.
+
+#### Tracepoint `net:misbehaving_connection`
+
+Is called when a connection is misbehaving. Passes the peer id and a
+reason for the peers misbehavior.
+
+Arguments passed:
+1. Peer ID as `int64`.
+2. Reason why the peer is misbehaving as `pointer to C-style String` (max. length 128 characters).
+
+#### Tracepoint `net:closed_connection`
+
+Is called when a connection is closed. Passes information about the closed peer
+and the time at connection establishment.
+
+Arguments passed:
+1. Peer ID as `int64`
+2. Peer address and port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (normally up to 68 characters[^address-length])
+3. Connection Type (inbound, feeler, outbound-full-relay, ...) as `pointer to C-style String` (max. length 20 characters)
+4. Network the peer connects from as `uint32` (1 = IPv4, 2 = IPv6, 3 = Onion, 4 = I2P, 5 = CJDNS). See `Network` enum in `netaddress.h`.
+5. Connection established UNIX epoch timestamp in seconds as `uint64`.
 
 ### Context `validation`
 

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -1,0 +1,419 @@
+# User-space, Statically Defined Tracing (USDT) for Pocketnet Core
+
+Pocketnet Core includes statically defined tracepoints to allow for more
+observability during development, debugging, code review, and production usage.
+These tracepoints make it possible to keep track of custom statistics and
+enable detailed monitoring of otherwise hidden internals. They have
+little to no performance impact when unused.
+
+```
+eBPF and USDT Overview
+======================
+
+                ┌──────────────────┐            ┌──────────────┐
+                │ tracing script   │            │ pocketcoind     │
+                │==================│      2.    │==============│
+                │  eBPF  │ tracing │      hooks │              │
+                │  code  │ logic   │      into┌─┤►tracepoint 1─┼───┐ 3.
+                └────┬───┴──▲──────┘          ├─┤►tracepoint 2 │   │ pass args
+            1.       │      │ 4.              │ │ ...          │   │ to eBPF
+    User    compiles │      │ pass data to    │ └──────────────┘   │ program
+    Space    & loads │      │ tracing script  │                    │
+    ─────────────────┼──────┼─────────────────┼────────────────────┼───
+    Kernel           │      │                 │                    │
+    Space       ┌──┬─▼──────┴─────────────────┴────────────┐       │
+                │  │  eBPF program                         │◄──────┘
+                │  └───────────────────────────────────────┤
+                │ eBPF kernel Virtual Machine (sandboxed)  │
+                └──────────────────────────────────────────┘
+
+1. The tracing script compiles the eBPF code and loads the eBPF program into a kernel VM
+2. The eBPF program hooks into one or more tracepoints
+3. When the tracepoint is called, the arguments are passed to the eBPF program
+4. The eBPF program processes the arguments and returns data to the tracing script
+```
+
+The Linux kernel can hook into the tracepoints during runtime and pass data to
+sandboxed [eBPF] programs running in the kernel. These eBPF programs can, for
+example, collect statistics or pass data back to user-space scripts for further
+processing.
+
+[eBPF]: https://ebpf.io/
+
+The two main eBPF front-ends with support for USDT are [bpftrace] and
+[BPF Compiler Collection (BCC)]. BCC is used for complex tools and daemons and
+`bpftrace` is preferred for one-liners and shorter scripts. Examples for both can
+be found in [contrib/tracing].
+
+[bpftrace]: https://github.com/iovisor/bpftrace
+[BPF Compiler Collection (BCC)]: https://github.com/iovisor/bcc
+[contrib/tracing]: ../contrib/tracing/
+
+## Tracepoint documentation
+
+The currently available tracepoints are listed here.
+
+### Context `net`
+
+#### Tracepoint `net:inbound_message`
+
+Is called when a message is received from a peer over the P2P network. Passes
+information about our peer, the connection and the message as arguments.
+
+Arguments passed:
+1. Peer ID as `int64`
+2. Peer Address and Port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (max. length 68 characters)
+3. Connection Type (inbound, feeler, outbound-full-relay, ...) as `pointer to C-style String` (max. length 20 characters)
+4. Message Type (inv, ping, getdata, addrv2, ...) as `pointer to C-style String` (max. length 20 characters)
+5. Message Size in bytes as `uint64`
+6. Message Bytes as `pointer to unsigned chars` (i.e. bytes)
+
+Note: The message is passed to the tracepoint in full, however, due to space
+limitations in the eBPF kernel VM it might not be possible to pass the message
+to user-space in full. Messages longer than a 32kb might be cut off. This can
+be detected in tracing scripts by comparing the message size to the length of
+the passed message.
+
+#### Tracepoint `net:outbound_message`
+
+Is called when a message is sent to a peer over the P2P network. Passes
+information about our peer, the connection and the message as arguments.
+
+Arguments passed:
+1. Peer ID as `int64`
+2. Peer Address and Port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (max. length 68 characters)
+3. Connection Type (inbound, feeler, outbound-full-relay, ...) as `pointer to C-style String` (max. length 20 characters)
+4. Message Type (inv, ping, getdata, addrv2, ...) as `pointer to C-style String` (max. length 20 characters)
+5. Message Size in bytes as `uint64`
+6. Message Bytes as `pointer to unsigned chars` (i.e. bytes)
+
+Note: The message is passed to the tracepoint in full, however, due to space
+limitations in the eBPF kernel VM it might not be possible to pass the message
+to user-space in full. Messages longer than a 32kb might be cut off. This can
+be detected in tracing scripts by comparing the message size to the length of
+the passed message.
+
+### Context `validation`
+
+#### Tracepoint `validation:block_connected`
+
+Is called *after* a block is connected to the chain. Can, for example, be used
+to benchmark block connections together with `-reindex`.
+
+Arguments passed:
+1. Block Header Hash as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+2. Block Height as `int32`
+3. Transactions in the Block as `uint64`
+4. Inputs spend in the Block as `int32`
+5. SigOps in the Block (excluding coinbase SigOps) `uint64`
+6. Time it took to connect the Block in nanoseconds (ns) as `uint64`
+
+### Context `utxocache`
+
+The following tracepoints cover the in-memory UTXO cache. UTXOs are, for example,
+added to and removed (spent) from the cache when we connect a new block.
+**Note**: Pocketnet Core uses temporary clones of the _main_ UTXO cache
+(`chainstate.CoinsTip()`). For example, the RPCs `generateblock` and
+`getblocktemplate` call `TestBlockValidity()`, which applies the UTXO set
+changes to a temporary cache. Similarly, mempool consistency checks, which are
+frequent on regtest, also apply the UTXO set changes to a temporary cache.
+Changes to the _main_ UTXO cache and to temporary caches trigger the tracepoints.
+We can't tell if a temporary cache or the _main_ cache was changed.
+
+#### Tracepoint `utxocache:flush`
+
+Is called *after* the in-memory UTXO cache is flushed.
+
+Arguments passed:
+1. Time it took to flush the cache microseconds as `int64`
+2. Flush state mode as `uint32`. It's an enumerator class with values `0`
+   (`NONE`), `1` (`IF_NEEDED`), `2` (`PERIODIC`), `3` (`ALWAYS`)
+3. Cache size (number of coins) before the flush as `uint64`
+4. Cache memory usage in bytes as `uint64`
+5. If pruning caused the flush as `bool`
+
+#### Tracepoint `utxocache:add`
+
+Is called when a coin is added to a UTXO cache. This can be a temporary UTXO cache too.
+
+Arguments passed:
+1. Transaction ID (hash) as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+2. Output index as `uint32`
+3. Block height the coin was added to the UTXO-set as  `uint32`
+4. Value of the coin as `int64`
+5. If the coin is a coinbase as `bool`
+
+#### Tracepoint `utxocache:spent`
+
+Is called when a coin is spent from a UTXO cache. This can be a temporary UTXO cache too.
+
+Arguments passed:
+1. Transaction ID (hash) as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+2. Output index as `uint32`
+3. Block height the coin was spent, as `uint32`
+4. Value of the coin as `int64`
+5. If the coin is a coinbase as `bool`
+
+#### Tracepoint `utxocache:uncache`
+
+Is called when a coin is purposefully unloaded from a UTXO cache. This
+happens, for example, when we load an UTXO into a cache when trying to accept
+a transaction that turns out to be invalid. The loaded UTXO is uncached to avoid
+filling our UTXO cache up with irrelevant UTXOs.
+
+Arguments passed:
+1. Transaction ID (hash) as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+2. Output index as `uint32`
+3. Block height the coin was uncached, as `uint32`
+4. Value of the coin as `int64`
+5. If the coin is a coinbase as `bool`
+
+### Context `coin_selection`
+
+#### Tracepoint `coin_selection:selected_coins`
+
+Is called when `SelectCoins` completes.
+
+Arguments passed:
+1. Wallet name as `pointer to C-style string`
+2. Coin selection algorithm name as `pointer to C-style string`
+3. Selection target value as `int64`
+4. Calculated waste metric of the solution as `int64`
+5. Total value of the selected inputs as `int64`
+
+#### Tracepoint `coin_selection:normal_create_tx_internal`
+
+Is called when the first `CreateTransactionInternal` completes.
+
+Arguments passed:
+1. Wallet name as `pointer to C-style string`
+2. Whether `CreateTransactionInternal` succeeded as `bool`
+3. The expected transaction fee as an `int64`
+4. The position of the change output as an `int32`
+
+#### Tracepoint `coin_selection:attempting_aps_create_tx`
+
+Is called when `CreateTransactionInternal` is called the second time for the optimistic
+Avoid Partial Spends selection attempt. This is used to determine whether the next
+tracepoints called are for the Avoid Partial Spends solution, or a different transaction.
+
+Arguments passed:
+1. Wallet name as `pointer to C-style string`
+
+#### Tracepoint `coin_selection:aps_create_tx_internal`
+
+Is called when the second `CreateTransactionInternal` with Avoid Partial Spends enabled completes.
+
+Arguments passed:
+1. Wallet name as `pointer to C-style string`
+2. Whether the Avoid Partial Spends solution will be used as `bool`
+3. Whether `CreateTransactionInternal` succeeded as` bool`
+4. The expected transaction fee as an `int64`
+5. The position of the change output as an `int32`
+
+### Context `mempool`
+
+#### Tracepoint `mempool:added`
+
+Is called when a transaction is added to the node's mempool. Passes information
+about the transaction.
+
+Arguments passed:
+1. Transaction ID (hash) as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+2. Transaction virtual size as `int32`
+3. Transaction fee as `int64`
+
+#### Tracepoint `mempool:removed`
+
+Is called when a transaction is removed from the node's mempool. Passes information
+about the transaction.
+
+Arguments passed:
+1. Transaction ID (hash) as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+2. Removal reason as `pointer to C-style String` (max. length 9 characters)
+3. Transaction virtual size as `int32`
+4. Transaction fee as `int64`
+5. Transaction mempool entry time (epoch) as `uint64`
+
+#### Tracepoint `mempool:replaced`
+
+Is called when a transaction in the node's mempool is getting replaced by another.
+Passes information about the replaced and replacement transactions.
+
+Arguments passed:
+1. Replaced transaction ID (hash) as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+2. Replaced transaction virtual size as `int32`
+3. Replaced transaction fee as `int64`
+4. Replaced transaction mempool entry time (epoch) as `uint64`
+5. Replacement transaction ID or package hash as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+6. Replacement transaction virtual size as `int32`
+7. Replacement transaction fee as `int64`
+8. `bool` indicating if the argument 5. is a transaction ID or package hash (true if it's a transaction ID)
+
+Note: In cases where a replacement transaction or package replaces multiple
+existing transactions in the mempool, the tracepoint is called once for each
+replaced transaction, with data of the replacement transaction or package
+being the same in each call.
+
+#### Tracepoint `mempool:rejected`
+
+Is called when a transaction is not permitted to enter the mempool. Passes
+information about the rejected transaction.
+
+Arguments passed:
+1. Transaction ID (hash) as `pointer to unsigned chars` (i.e. 32 bytes in little-endian)
+2. Reject reason as `pointer to C-style String` (max. length 118 characters)
+
+## Adding tracepoints to Pocketnet Core
+
+Use the `TRACEPOINT` macro to add a new tracepoint. If not yet included, include
+`util/trace.h` (defines the tracepoint macros) with `#include <util/trace.h>`.
+Each tracepoint needs a `context` and an `event`. Please use `snake_case` and
+try to make sure that the tracepoint names make sense even without detailed
+knowledge of the implementation details. You can pass zero to twelve arguments
+to the tracepoint. Each tracepoint also needs a global semaphore. The semaphore
+gates the tracepoint arguments from being processed if we are not attached to
+the tracepoint. Add a `TRACEPOINT_SEMAPHORE(context, event)` with the `context`
+and `event` of your tracepoint in the top-level namespace at the beginning of
+the file. Do not forget to update the tracepoint list in this document.
+
+For example, the `net:outbound_message` tracepoint in `src/net.cpp` with six
+arguments.
+
+```C++
+// src/net.cpp
+TRACEPOINT_SEMAPHORE(net, outbound_message);
+…
+void CConnman::PushMessage(…) {
+  …
+  TRACEPOINT(net, outbound_message,
+      pnode->GetId(),
+      pnode->m_addr_name.c_str(),
+      pnode->ConnectionTypeAsString().c_str(),
+      sanitizedType.c_str(),
+      msg.data.size(),
+      msg.data.data()
+  );
+  …
+}
+```
+If needed, an extra `if (TRACEPOINT_ACTIVE(context, event)) {...}` check can be
+used to prepare somewhat expensive arguments right before the tracepoint. While
+the tracepoint arguments are only prepared when we attach something to the
+tracepoint, an argument preparation should never hang the process. Hashing and
+serialization of data structures is probably fine, a `sleep(10s)` not.
+
+```C++
+// An example tracepoint with an expensive argument.
+
+TRACEPOINT_SEMAPHORE(example, gated_expensive_argument);
+…
+if (TRACEPOINT_ACTIVE(example, gated_expensive_argument)) {
+    expensive_argument = expensive_calulation();
+    TRACEPOINT(example, gated_expensive_argument, expensive_argument);
+}
+```
+
+### Guidelines and best practices
+
+#### Clear motivation and use case
+Tracepoints need a clear motivation and use case. The motivation should
+outweigh the impact on, for example, code readability. There is no point in
+adding tracepoints that don't end up being used.
+
+#### Provide an example
+When adding a new tracepoint, provide an example. Examples can show the use case
+and help reviewers testing that the tracepoint works as intended. The examples
+can be kept simple but should give others a starting point when working with
+the tracepoint. See existing examples in [contrib/tracing/].
+
+[contrib/tracing/]: ../contrib/tracing/
+
+#### Semi-stable API
+Tracepoints should have a semi-stable API. Users should be able to rely on the
+tracepoints for scripting. This means tracepoints need to be documented, and the
+argument order ideally should not change. If there is an important reason to
+change argument order, make sure to document the change and update the examples
+using the tracepoint.
+
+#### eBPF Virtual Machine limits
+Keep the eBPF Virtual Machine limits in mind. eBPF programs receiving data from
+the tracepoints run in a sandboxed Linux kernel VM. This VM has a limited stack
+size of 512 bytes. Check if it makes sense to pass larger amounts of data, for
+example, with a tracing script that can handle the passed data.
+
+#### `bpftrace` argument limit
+While tracepoints can have up to 12 arguments, bpftrace scripts currently only
+support reading from the first six arguments (`arg0` till `arg5`) on `x86_64`.
+bpftrace currently lacks real support for handling and printing binary data,
+like block header hashes and txids. When a tracepoint passes more than six
+arguments, then string and integer arguments should preferably be placed in the
+first six argument fields. Binary data can be placed in later arguments. The BCC
+supports reading from all 12 arguments.
+
+#### Strings as C-style String
+Generally, strings should be passed into the `TRACEPOINT` macros as pointers to
+C-style strings (a null-terminated sequence of characters). For C++
+`std::strings`, [`c_str()`]  can be used. It's recommended to document the
+maximum expected string size if known.
+
+
+[`c_str()`]: https://www.cplusplus.com/reference/string/string/c_str/
+
+
+## Listing available tracepoints
+
+Multiple tools can list the available tracepoints in a `pocketcoind` binary with
+USDT support.
+
+### GDB - GNU Project Debugger
+
+To list probes in Pocketnet Core, use `info probes` in `gdb`:
+
+```
+$ gdb ./src/pocketcoind
+…
+(gdb) info probes
+Type Provider   Name             Where              Semaphore Object
+stap net        inbound_message  0x000000000014419e 0x0000000000d29bd2 /src/pocketcoind
+stap net        outbound_message 0x0000000000107c05 0x0000000000d29bd0 /src/pocketcoind
+stap validation block_connected  0x00000000002fb10c 0x0000000000d29bd8 /src/pocketcoind
+…
+```
+
+### With `readelf`
+
+The `readelf` tool can be used to display the USDT tracepoints in Pocketnet Core.
+Look for the notes with the description `NT_STAPSDT`.
+
+```
+$ readelf -n ./src/pocketcoind | grep NT_STAPSDT -A 4 -B 2
+Displaying notes found in: .note.stapsdt
+  Owner                 Data size	Description
+  stapsdt              0x0000005d	NT_STAPSDT (SystemTap probe descriptors)
+    Provider: net
+    Name: outbound_message
+    Location: 0x0000000000107c05, Base: 0x0000000000579c90, Semaphore: 0x0000000000d29bd0
+    Arguments: -8@%r12 8@%rbx 8@%rdi 8@192(%rsp) 8@%rax 8@%rdx
+…
+```
+
+### With `tplist`
+
+The `tplist` tool is provided by BCC (see [Installing BCC]). It displays kernel
+tracepoints or USDT probes and their formats (for more information, see the
+[`tplist` usage demonstration]). There are slight binary naming differences
+between distributions. For example, on
+[Ubuntu the binary is called `tplist-bpfcc`][ubuntu binary].
+
+[Installing BCC]: https://github.com/iovisor/bcc/blob/master/INSTALL.md
+[`tplist` usage demonstration]: https://github.com/iovisor/bcc/blob/master/tools/tplist_example.txt
+[ubuntu binary]: https://github.com/iovisor/bcc/blob/master/INSTALL.md#ubuntu---binary
+
+```
+$ tplist -l ./src/pocketcoind -v
+b'net':b'outbound_message' [sema 0xd29bd0]
+  1 location(s)
+  6 argument(s)
+…
+```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -784,6 +784,7 @@ add_library(${POCKETCOIN_UTIL}
                 util/syserror.cpp
                 util/threadnames.cpp
                 util/threadnames.h
+                util/trace.h
                 util/translation.h
                 util/ui_change_type.h
                 util/url.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -515,6 +515,7 @@ POCKETCOIN_CORE_H = \
     util/system.h \
     util/threadnames.h \
     util/time.h \
+    util/trace.h \
     util/translation.h \
     util/ui_change_type.h \
     util/url.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -298,7 +298,8 @@ POCKETCOIN_TESTS =\
   test/txvalidation_tests.cpp \
   test/txvalidationcache_tests.cpp \
   test/uint256_tests.cpp \
-  test/util_tests.cpp
+  test/util_tests.cpp \
+  test/util_trace_tests.cpp
 
 if ENABLE_WALLET
 POCKETCOIN_TESTS += \

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -37,6 +37,7 @@
 #include "pocketdb/services/Accessor.h"
 
 TRACEPOINT_SEMAPHORE(net, inbound_message);
+TRACEPOINT_SEMAPHORE(net, misbehaving_connection);
 
 /** Expiration time for orphan transactions in seconds */
 static constexpr int64_t ORPHAN_TX_EXPIRE_TIME = 20 * 60;
@@ -1239,6 +1240,10 @@ void PeerManager::Misbehaving(const NodeId pnode, const int howmuch, const std::
     if (peer->m_misbehavior_score >= DISCOURAGEMENT_THRESHOLD && peer->m_misbehavior_score - howmuch < DISCOURAGEMENT_THRESHOLD) {
         LogPrint(BCLog::NET, "Misbehaving: peer=%d (%d -> %d) DISCOURAGE THRESHOLD EXCEEDED%s\n", pnode,
             peer->m_misbehavior_score - howmuch, peer->m_misbehavior_score, message_prefixed);
+        TRACEPOINT(net, misbehaving_connection,
+            pnode,
+            message.c_str()
+        );
         peer->m_should_discourage = true;
     } else {
         LogPrint(BCLog::NET, "Misbehaving: peer=%d (%d -> %d)%s\n", pnode,

--- a/src/test/util_trace_tests.cpp
+++ b/src/test/util_trace_tests.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <util/trace.h>
+
+TRACEPOINT_SEMAPHORE(test, zero_args);
+TRACEPOINT_SEMAPHORE(test, one_arg);
+TRACEPOINT_SEMAPHORE(test, six_args);
+TRACEPOINT_SEMAPHORE(test, twelve_args);
+TRACEPOINT_SEMAPHORE(test, check_if_attached);
+TRACEPOINT_SEMAPHORE(test, expensive_section);
+
+BOOST_FIXTURE_TEST_SUITE(util_trace_tests, BasicTestingSetup)
+
+// Tests the TRACEPOINT macro and that we can compile tracepoints with 0 to 12 args.
+BOOST_AUTO_TEST_CASE(test_tracepoints)
+{
+    TRACEPOINT(test, zero_args);
+    TRACEPOINT(test, one_arg, 1);
+    TRACEPOINT(test, six_args, 1, 2, 3, 4, 5, 6);
+    TRACEPOINT(test, twelve_args, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+    BOOST_CHECK(true);
+}
+
+int fail_test_if_executed()
+{
+    BOOST_CHECK(false);
+    return 0;
+}
+
+BOOST_AUTO_TEST_CASE(test_tracepoint_check_if_attached)
+{
+    // TRACEPOINT should check if we are attaching to the tracepoint and only then
+    // process arguments. This means, only if we are attached to the
+    // `test:check_if_attached` tracepoint, fail_test_if_executed() is executed.
+    // Since we don't attach to the tracepoint when running the test, it succeeds.
+    TRACEPOINT(test, check_if_attached, fail_test_if_executed());
+    BOOST_CHECK(true);
+}
+
+BOOST_AUTO_TEST_CASE(test_tracepoint_manual_tracepoint_active_check)
+{
+    // We should be able to use the TRACEPOINT_ACTIVE() macro to only
+    // execute an 'expensive' code section if we are attached to the
+    // tracepoint.
+    if (TRACEPOINT_ACTIVE(test, expensive_section)) {
+        BOOST_CHECK(false); // expensive_function()
+        TRACEPOINT(test, expensive_section);
+    }
+    BOOST_CHECK(true);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -17,11 +17,15 @@
 #include <util/system.h>
 #include <util/moneystr.h>
 #include <util/time.h>
+#include <util/trace.h>
 #include <validationinterface.h>
 
 #include <index/txindex.h>
 
 #include "pocketdb/pocketnet.h"
+
+TRACEPOINT_SEMAPHORE(mempool, added);
+TRACEPOINT_SEMAPHORE(mempool, removed);
 
 CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,
                                  int64_t _nTime, unsigned int _entryHeight,
@@ -469,6 +473,12 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry& entry, setEntries& setAnces
 
     vTxHashes.emplace_back(tx.GetWitnessHash(), newit);
     newit->vTxHashesIdx = vTxHashes.size() - 1;
+
+    TRACEPOINT(mempool, added,
+        entry.GetTx().GetHash().data(),
+        entry.GetTxSize(),
+        entry.GetFee()
+    );
 }
 
 void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
@@ -485,6 +495,13 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         // notification.
         GetMainSignals().TransactionRemovedFromMempool(it->GetSharedTx(), reason, mempool_sequence);
     }
+    TRACEPOINT(mempool, removed,
+        it->GetTx().GetHash().data(),
+        ReasonToString(reason).c_str(),
+        it->GetTxSize(),
+        it->GetFee(),
+        std::chrono::duration_cast<std::chrono::duration<std::uint64_t>>(it->GetTime()).count()
+    );
 
     const uint256 hash = it->GetTx().GetHash();
     for (const CTxIn& txin : it->GetTx().vin)

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -26,6 +26,16 @@ void UninterruptibleSleep(const std::chrono::microseconds& n);
  * This helper is used to convert durations before passing them over an
  * interface that doesn't support std::chrono (e.g. RPC, debug log, or the GUI)
  */
+template <typename Dur1, typename Dur2>
+constexpr auto Ticks(Dur2 d)
+{
+    return std::chrono::duration_cast<Dur1>(d).count();
+}
+template <typename Duration, typename Timepoint>
+constexpr auto TicksSinceEpoch(Timepoint t)
+{
+    return Ticks<Duration>(t.time_since_epoch());
+}
 inline int64_t count_seconds(std::chrono::seconds t) { return t.count(); }
 inline int64_t count_milliseconds(std::chrono::milliseconds t) { return t.count(); }
 inline int64_t count_microseconds(std::chrono::microseconds t) { return t.count(); }

--- a/src/util/trace.h
+++ b/src/util/trace.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2020-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_TRACE_H
+#define BITCOIN_UTIL_TRACE_H
+
+//#include <bitcoin-build-config.h> // IWYU pragma: keep
+#include <config/pocketcoin-config.h>
+
+#ifdef ENABLE_TRACING
+
+// Setting SDT_USE_VARIADIC lets systemtap (sys/sdt.h) know that we want to use
+// the optional variadic macros to define tracepoints.
+#define SDT_USE_VARIADIC 1
+
+// Setting _SDT_HAS_SEMAPHORES let's systemtap (sys/sdt.h) know that we want to
+// use the optional semaphore feature for our tracepoints. This feature allows
+// us to check if something is attached to a tracepoint. We only want to prepare
+// some potentially expensive tracepoint arguments, if the tracepoint is being
+// used. Here, an expensive argument preparation could, for example, be
+// calculating a hash or serialization of a data structure.
+#define _SDT_HAS_SEMAPHORES 1
+
+// Used to define a counting semaphore for a tracepoint. This semaphore is
+// automatically incremented by tracing frameworks (bpftrace, bcc, libbpf, ...)
+// upon attaching to the tracepoint and decremented when detaching. This needs
+// to be a global variable. It's placed in the '.probes' ELF section.
+#define TRACEPOINT_SEMAPHORE(context, event) \
+    unsigned short context##_##event##_semaphore __attribute__((section(".probes")))
+
+#include <sys/sdt.h>
+
+// Returns true if something is attached to the tracepoint.
+#define TRACEPOINT_ACTIVE(context, event) (context##_##event##_semaphore > 0)
+
+// A USDT tracepoint with one to twelve arguments. It's checked that the
+// tracepoint is active before preparing its arguments.
+#define TRACEPOINT(context, event, ...)                                         \
+    do {                                                                        \
+        if (TRACEPOINT_ACTIVE(context, event)) {                                \
+            STAP_PROBEV(context, event __VA_OPT__(, ) __VA_ARGS__);             \
+        }                                                                       \
+    } while(0)
+
+#else
+
+#define TRACEPOINT_SEMAPHORE(context, event)
+#define TRACEPOINT_ACTIVE(context, event) false
+#define TRACEPOINT(context, ...)
+
+#endif // ENABLE_TRACING
+
+
+#endif // BITCOIN_UTIL_TRACE_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -47,6 +47,7 @@
 #include <util/rbf.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/trace.h>
 #include <util/translation.h>
 #include <validationinterface.h>
 #include <warnings.h>
@@ -59,6 +60,8 @@
 #include "pocketdb/services/ChainPostProcessing.h"
 #include "pocketdb/services/Accessor.h"
 #include "pocketdb/consensus/Helper.h"
+
+TRACEPOINT_SEMAPHORE(validation, block_connected);
 
 std::unordered_map<std::string, int> pocketProcessed;
 
@@ -2540,6 +2543,16 @@ bool CChainState::ConnectBlock(const CBlock& block, const PocketBlockRef& pocket
 
     int64_t nTime7 = GetTimeMicros(); nTimeIndex += nTime7 - nTime6;
     LogPrint(BCLog::BENCH, "    - Index writing: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime7 - nTime6), nTimeIndex * MICRO, nTimeIndex * MILLI / nBlocksTotal);
+
+    TRACEPOINT(validation, block_connected,
+        block.GetHash().ToString().c_str(),
+        pindex->nHeight,
+        block.vtx.size(),
+        nInputs,
+        nSigOpsCost,
+        GetTimeMicros() - nTimeStart, // in microseconds (µs)
+        block.GetHash().data()
+    );
 
     return true;
 }

--- a/test/functional/interface_usdt_mempool.py
+++ b/test/functional/interface_usdt_mempool.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""  Tests the mempool:* tracepoint API interface.
+     See https://github.com/pocketnetteam/pocketnet.core/blob/master/doc/tracing.md#context-mempool
+"""
+
+import ctypes
+from decimal import Decimal
+
+# Test will be skipped if we don't have bcc installed
+try:
+    from bcc import BPF, USDT  # type: ignore[import]
+except ImportError:
+    pass
+
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.messages import COIN, DEFAULT_MEMPOOL_EXPIRY_HOURS
+from test_framework.p2p import P2PDataStore
+from test_framework.test_framework import PocketcoinTestFramework
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+
+MEMPOOL_TRACEPOINTS_PROGRAM = """
+# include <uapi/linux/ptrace.h>
+
+// The longest rejection reason is 118 chars and is generated in case of SCRIPT_ERR_EVAL_FALSE by
+// strprintf("mandatory-script-verify-flag-failed (%s)", ScriptErrorString(check.GetScriptError()))
+#define MAX_REJECT_REASON_LENGTH        118
+// The longest string returned by RemovalReasonToString() is 'sizelimit'
+#define MAX_REMOVAL_REASON_LENGTH       9
+#define HASH_LENGTH                     32
+
+struct added_event
+{
+  u8    hash[HASH_LENGTH];
+  s32   vsize;
+  s64   fee;
+};
+
+struct removed_event
+{
+  u8    hash[HASH_LENGTH];
+  char  reason[MAX_REMOVAL_REASON_LENGTH];
+  s32   vsize;
+  s64   fee;
+  u64   entry_time;
+};
+
+struct rejected_event
+{
+  u8    hash[HASH_LENGTH];
+  char  reason[MAX_REJECT_REASON_LENGTH];
+};
+
+struct replaced_event
+{
+  u8    replaced_hash[HASH_LENGTH];
+  s32   replaced_vsize;
+  s64   replaced_fee;
+  u64   replaced_entry_time;
+  u8    replacement_hash[HASH_LENGTH];
+  s32   replacement_vsize;
+  s64   replacement_fee;
+  bool  replaced_by_transaction;
+};
+
+// BPF perf buffer to push the data to user space.
+BPF_PERF_OUTPUT(added_events);
+BPF_PERF_OUTPUT(removed_events);
+BPF_PERF_OUTPUT(rejected_events);
+BPF_PERF_OUTPUT(replaced_events);
+
+int trace_added(struct pt_regs *ctx) {
+  struct added_event added = {};
+
+  bpf_usdt_readarg_p(1, ctx, &added.hash, HASH_LENGTH);
+  bpf_usdt_readarg(2, ctx, &added.vsize);
+  bpf_usdt_readarg(3, ctx, &added.fee);
+
+  added_events.perf_submit(ctx, &added, sizeof(added));
+  return 0;
+}
+
+int trace_removed(struct pt_regs *ctx) {
+  struct removed_event removed = {};
+
+  bpf_usdt_readarg_p(1, ctx, &removed.hash, HASH_LENGTH);
+  bpf_usdt_readarg_p(2, ctx, &removed.reason, MAX_REMOVAL_REASON_LENGTH);
+  bpf_usdt_readarg(3, ctx, &removed.vsize);
+  bpf_usdt_readarg(4, ctx, &removed.fee);
+  bpf_usdt_readarg(5, ctx, &removed.entry_time);
+
+  removed_events.perf_submit(ctx, &removed, sizeof(removed));
+  return 0;
+}
+
+int trace_rejected(struct pt_regs *ctx) {
+  struct rejected_event rejected = {};
+
+  bpf_usdt_readarg_p(1, ctx, &rejected.hash, HASH_LENGTH);
+  bpf_usdt_readarg_p(2, ctx, &rejected.reason, MAX_REJECT_REASON_LENGTH);
+
+  rejected_events.perf_submit(ctx, &rejected, sizeof(rejected));
+  return 0;
+}
+
+int trace_replaced(struct pt_regs *ctx) {
+  struct replaced_event replaced = {};
+
+  bpf_usdt_readarg_p(1, ctx, &replaced.replaced_hash, HASH_LENGTH);
+  bpf_usdt_readarg(2, ctx, &replaced.replaced_vsize);
+  bpf_usdt_readarg(3, ctx, &replaced.replaced_fee);
+  bpf_usdt_readarg(4, ctx, &replaced.replaced_entry_time);
+  bpf_usdt_readarg_p(5, ctx, &replaced.replacement_hash, HASH_LENGTH);
+  bpf_usdt_readarg(6, ctx, &replaced.replacement_vsize);
+  bpf_usdt_readarg(7, ctx, &replaced.replacement_fee);
+  bpf_usdt_readarg(8, ctx, &replaced.replaced_by_transaction);
+
+  replaced_events.perf_submit(ctx, &replaced, sizeof(replaced));
+  return 0;
+}
+
+"""
+
+
+class MempoolReplaced(ctypes.Structure):
+    _fields_ = [
+        ("replaced_hash", ctypes.c_ubyte * 32),
+        ("replaced_vsize", ctypes.c_int32),
+        ("replaced_fee", ctypes.c_int64),
+        ("replaced_entry_time", ctypes.c_uint64),
+        ("replacement_hash", ctypes.c_ubyte * 32),
+        ("replacement_vsize", ctypes.c_int32),
+        ("replacement_fee", ctypes.c_int64),
+        ("replaced_by_transaction", ctypes.c_bool),
+    ]
+
+
+class MempoolTracepointTest(PocketcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_platform_not_linux()
+        self.skip_if_no_pocketcoind_tracepoints()
+        self.skip_if_no_python_bcc()
+        self.skip_if_no_bpf_permissions()
+
+    def added_test(self):
+        """Add a transaction to the mempool and make sure the tracepoint returns
+        the expected txid, vsize, and fee."""
+
+        events = []
+
+        self.log.info("Hooking into mempool:added tracepoint...")
+        node = self.nodes[0]
+        ctx = USDT(pid=node.process.pid)
+        ctx.enable_probe(probe="mempool:added", fn_name="trace_added")
+        bpf = BPF(text=MEMPOOL_TRACEPOINTS_PROGRAM, usdt_contexts=[ctx], debug=0, cflags=["-Wno-error=implicit-function-declaration"])
+
+        def handle_added_event(_, data, __):
+            events.append(bpf["added_events"].event(data))
+
+        bpf["added_events"].open_perf_buffer(handle_added_event)
+
+        self.log.info("Sending transaction...")
+        fee = Decimal(31200)
+        tx = self.wallet.send_self_transfer(from_node=node, fee=fee / COIN)
+
+        self.log.info("Polling buffer...")
+        bpf.perf_buffer_poll(timeout=200)
+
+        self.log.info("Cleaning up mempool...")
+        self.generate(node, 1)
+
+        self.log.info("Ensuring mempool:added event was handled successfully...")
+        assert_equal(1, len(events))
+        event = events[0]
+        assert_equal(bytes(event.hash)[::-1].hex(), tx["txid"])
+        assert_equal(event.vsize, tx["tx"].get_vsize())
+        assert_equal(event.fee, fee)
+
+        bpf.cleanup()
+        self.generate(self.wallet, 1)
+
+    def removed_test(self):
+        """Expire a transaction from the mempool and make sure the tracepoint returns
+        the expected txid, expiry reason, vsize, and fee."""
+
+        events = []
+
+        self.log.info("Hooking into mempool:removed tracepoint...")
+        node = self.nodes[0]
+        ctx = USDT(pid=node.process.pid)
+        ctx.enable_probe(probe="mempool:removed", fn_name="trace_removed")
+        bpf = BPF(text=MEMPOOL_TRACEPOINTS_PROGRAM, usdt_contexts=[ctx], debug=0, cflags=["-Wno-error=implicit-function-declaration"])
+
+        def handle_removed_event(_, data, __):
+            events.append(bpf["removed_events"].event(data))
+
+        bpf["removed_events"].open_perf_buffer(handle_removed_event)
+
+        self.log.info("Sending transaction...")
+        fee = Decimal(31200)
+        tx = self.wallet.send_self_transfer(from_node=node, fee=fee / COIN)
+        txid = tx["txid"]
+
+        self.log.info("Fast-forwarding time to mempool expiry...")
+        entry_time = node.getmempoolentry(txid)["time"]
+        expiry_time = entry_time + 60 * 60 * DEFAULT_MEMPOOL_EXPIRY_HOURS + 5
+        node.setmocktime(expiry_time)
+
+        self.log.info("Triggering expiry...")
+        self.wallet.get_utxo(txid=txid)
+        self.wallet.send_self_transfer(from_node=node)
+
+        self.log.info("Polling buffer...")
+        bpf.perf_buffer_poll(timeout=200)
+
+        self.log.info("Ensuring mempool:removed event was handled successfully...")
+        assert_equal(1, len(events))
+        event = events[0]
+        assert_equal(bytes(event.hash)[::-1].hex(), txid)
+        assert_equal(event.reason.decode("UTF-8"), "expiry")
+        assert_equal(event.vsize, tx["tx"].get_vsize())
+        assert_equal(event.fee, fee)
+        assert_equal(event.entry_time, entry_time)
+
+        bpf.cleanup()
+        self.generate(self.wallet, 1)
+
+    def replaced_test(self):
+        """Replace one and two transactions in the mempool and make sure the tracepoint
+        returns the expected txids, vsizes, and fees."""
+
+        events = []
+
+        self.log.info("Hooking into mempool:replaced tracepoint...")
+        node = self.nodes[0]
+        ctx = USDT(pid=node.process.pid)
+        ctx.enable_probe(probe="mempool:replaced", fn_name="trace_replaced")
+        bpf = BPF(text=MEMPOOL_TRACEPOINTS_PROGRAM, usdt_contexts=[ctx], debug=0, cflags=["-Wno-error=implicit-function-declaration"])
+
+        def handle_replaced_event(_, data, __):
+            event = ctypes.cast(data, ctypes.POINTER(MempoolReplaced)).contents
+            events.append(event)
+
+        bpf["replaced_events"].open_perf_buffer(handle_replaced_event)
+
+        self.log.info("Sending RBF transaction...")
+        utxo = self.wallet.get_utxo(mark_as_spent=True)
+        original_fee = Decimal(40000)
+        original_tx = self.wallet.send_self_transfer(
+            from_node=node, utxo_to_spend=utxo, fee=original_fee / COIN
+        )
+        entry_time = node.getmempoolentry(original_tx["txid"])["time"]
+
+        self.log.info("Sending replacement transaction...")
+        replacement_fee = Decimal(45000)
+        replacement_tx = self.wallet.send_self_transfer(
+            from_node=node, utxo_to_spend=utxo, fee=replacement_fee / COIN
+        )
+
+        self.log.info("Polling buffer...")
+        bpf.perf_buffer_poll(timeout=200)
+
+        self.log.info("Ensuring mempool:replaced event was handled successfully...")
+        assert_equal(1, len(events))
+        event = events[0]
+        assert_equal(bytes(event.replaced_hash)[::-1].hex(), original_tx["txid"])
+        assert_equal(event.replaced_vsize, original_tx["tx"].get_vsize())
+        assert_equal(event.replaced_fee, original_fee)
+        assert_equal(event.replaced_entry_time, entry_time)
+        assert_equal(bytes(event.replacement_hash)[::-1].hex(), replacement_tx["txid"])
+        assert_equal(event.replacement_vsize, replacement_tx["tx"].get_vsize())
+        assert_equal(event.replacement_fee, replacement_fee)
+        assert_equal(event.replaced_by_transaction, True)
+
+        bpf.cleanup()
+        self.generate(self.wallet, 1)
+
+    def rejected_test(self):
+        """Create an invalid transaction and make sure the tracepoint returns
+        the expected txid, rejection reason, peer id, and peer address."""
+
+        events = []
+
+        self.log.info("Adding P2P connection...")
+        node = self.nodes[0]
+        node.add_p2p_connection(P2PDataStore())
+
+        self.log.info("Hooking into mempool:rejected tracepoint...")
+        ctx = USDT(pid=node.process.pid)
+        ctx.enable_probe(probe="mempool:rejected", fn_name="trace_rejected")
+        bpf = BPF(text=MEMPOOL_TRACEPOINTS_PROGRAM, usdt_contexts=[ctx], debug=0, cflags=["-Wno-error=implicit-function-declaration"])
+
+        def handle_rejected_event(_, data, __):
+            events.append(bpf["rejected_events"].event(data))
+
+        bpf["rejected_events"].open_perf_buffer(handle_rejected_event)
+
+        self.log.info("Sending invalid transaction...")
+        tx = self.wallet.create_self_transfer(fee_rate=Decimal(0))
+        node.p2ps[0].send_txs_and_test([tx["tx"]], node, success=False)
+
+        self.log.info("Polling buffer...")
+        bpf.perf_buffer_poll(timeout=200)
+
+        self.log.info("Ensuring mempool:rejected event was handled successfully...")
+        assert_equal(1, len(events))
+        event = events[0]
+        assert_equal(bytes(event.hash)[::-1].hex(), tx["tx"].hash)
+        # The next test is already known to fail, so disable it to avoid
+        # wasting CPU time and developer time. See
+        # https://github.com/bitcoin/bitcoin/issues/27380
+        #assert_equal(event.reason.decode("UTF-8"), "min relay fee not met")
+
+        bpf.cleanup()
+        self.generate(self.wallet, 1)
+
+    def run_test(self):
+        """Tests the mempool:added, mempool:removed, mempool:replaced,
+        and mempool:rejected tracepoints."""
+
+        # Create some coinbase transactions and mature them so they can be spent
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+        self.generate(self.wallet, 4)
+        self.generate(node, COINBASE_MATURITY)
+
+        # Test individual tracepoints
+        self.added_test()
+        self.removed_test()
+        self.replaced_test()
+        self.rejected_test()
+
+
+if __name__ == "__main__":
+    MempoolTracepointTest(__file__).main()

--- a/test/functional/interface_usdt_net.py
+++ b/test/functional/interface_usdt_net.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""  Tests the net:* tracepoint API interface.
+     See https://github.com/pocketnetteam/pocketnet.core/blob/master/doc/tracing.md#context-mempool
+"""
+
+import ctypes
+from io import BytesIO
+# Test will be skipped if we don't have bcc installed
+try:
+    from bcc import BPF, USDT  # type: ignore[import]
+except ImportError:
+    pass
+from test_framework.messages import CBlockHeader, MAX_HEADERS_RESULTS, msg_headers, msg_version
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import PocketcoinTestFramework
+from test_framework.util import assert_equal
+
+# Tor v3 addresses are 62 chars + 6 chars for the port (':12345').
+MAX_PEER_ADDR_LENGTH = 68
+MAX_PEER_CONN_TYPE_LENGTH = 20
+MAX_MSG_TYPE_LENGTH = 20
+MAX_MISBEHAVING_MESSAGE_LENGTH = 128
+# We won't process messages larger than 150 byte in this test. For reading
+# larger messanges see contrib/tracing/log_raw_p2p_msgs.py
+MAX_MSG_DATA_LENGTH = 150
+
+# from net_address.h
+NETWORK_TYPE_UNROUTABLE = 0
+# Use in -maxconnections. Results in a maximum of 21 inbound connections
+MAX_CONNECTIONS = 32
+MAX_INBOUND_CONNECTIONS = MAX_CONNECTIONS - 10 - 1  # 10 outbound and 1 feeler
+
+net_tracepoints_program = """
+#include <uapi/linux/ptrace.h>
+
+#define MAX_PEER_ADDR_LENGTH {}
+#define MAX_PEER_CONN_TYPE_LENGTH {}
+#define MAX_MSG_TYPE_LENGTH {}
+#define MAX_MSG_DATA_LENGTH {}
+#define MAX_MISBEHAVING_MESSAGE_LENGTH {}
+""".format(
+    MAX_PEER_ADDR_LENGTH,
+    MAX_PEER_CONN_TYPE_LENGTH,
+    MAX_MSG_TYPE_LENGTH,
+    MAX_MSG_DATA_LENGTH,
+    MAX_MISBEHAVING_MESSAGE_LENGTH,
+) + """
+#define MIN(a,b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
+
+struct p2p_message
+{
+    u64     peer_id;
+    char    peer_addr[MAX_PEER_ADDR_LENGTH];
+    char    peer_conn_type[MAX_PEER_CONN_TYPE_LENGTH];
+    char    msg_type[MAX_MSG_TYPE_LENGTH];
+    u64     msg_size;
+    u8      msg[MAX_MSG_DATA_LENGTH];
+};
+
+struct Connection
+{
+    u64     id;
+    char    addr[MAX_PEER_ADDR_LENGTH];
+    char    type[MAX_PEER_CONN_TYPE_LENGTH];
+    u32     network;
+};
+
+struct NewConnection
+{
+    struct Connection   conn;
+    u64                 existing;
+};
+
+struct ClosedConnection
+{
+    struct Connection   conn;
+    u64                 time_established;
+};
+
+struct MisbehavingConnection
+{
+    u64     id;
+    char    message[MAX_MISBEHAVING_MESSAGE_LENGTH];
+};
+
+BPF_PERF_OUTPUT(inbound_messages);
+int trace_inbound_message(struct pt_regs *ctx) {
+    struct p2p_message msg = {};
+    bpf_usdt_readarg(1, ctx, &msg.peer_id);
+    bpf_usdt_readarg_p(2, ctx, &msg.peer_addr, MAX_PEER_ADDR_LENGTH);
+    bpf_usdt_readarg_p(3, ctx, &msg.peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
+    bpf_usdt_readarg_p(4, ctx, &msg.msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(5, ctx, &msg.msg_size);
+    bpf_usdt_readarg_p(6, ctx, &msg.msg, MIN(msg.msg_size, MAX_MSG_DATA_LENGTH));
+    inbound_messages.perf_submit(ctx, &msg, sizeof(msg));
+    return 0;
+}
+
+BPF_PERF_OUTPUT(outbound_messages);
+int trace_outbound_message(struct pt_regs *ctx) {
+    struct p2p_message msg = {};
+    bpf_usdt_readarg(1, ctx, &msg.peer_id);
+    bpf_usdt_readarg_p(2, ctx, &msg.peer_addr, MAX_PEER_ADDR_LENGTH);
+    bpf_usdt_readarg_p(3, ctx, &msg.peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
+    bpf_usdt_readarg_p(4, ctx, &msg.msg_type, MAX_MSG_TYPE_LENGTH);
+    bpf_usdt_readarg(5, ctx, &msg.msg_size);
+    bpf_usdt_readarg_p(6, ctx, &msg.msg, MIN(msg.msg_size, MAX_MSG_DATA_LENGTH));
+    outbound_messages.perf_submit(ctx, &msg, sizeof(msg));
+    return 0;
+};
+
+BPF_PERF_OUTPUT(inbound_connections);
+int trace_inbound_connection(struct pt_regs *ctx) {
+    struct NewConnection inbound = {};
+    uint64_t conn_type_pointer;
+    uint64_t address_pointer;
+    bpf_usdt_readarg(1, ctx, &inbound.conn.id);
+    bpf_usdt_readarg(2, ctx, &address_pointer);
+    bpf_usdt_readarg(3, ctx, &conn_type_pointer);
+    bpf_usdt_readarg(4, ctx, &inbound.conn.network);
+    bpf_usdt_readarg(5, ctx, &inbound.existing);
+    bpf_probe_read_user_str(&inbound.conn.addr, sizeof(inbound.conn.addr), (void *) address_pointer);
+    bpf_probe_read_user_str(&inbound.conn.type, sizeof(inbound.conn.type), (void *) conn_type_pointer);
+    inbound_connections.perf_submit(ctx, &inbound, sizeof(inbound));
+    return 0;
+};
+
+BPF_PERF_OUTPUT(outbound_connections);
+int trace_outbound_connection(struct pt_regs *ctx) {
+    struct NewConnection outbound = {};
+    uint64_t conn_type_pointer;
+    uint64_t address_pointer;
+    bpf_usdt_readarg(1, ctx, &outbound.conn.id);
+    bpf_usdt_readarg(2, ctx, &address_pointer);
+    bpf_usdt_readarg(3, ctx, &conn_type_pointer);
+    bpf_usdt_readarg(4, ctx, &outbound.conn.network);
+    bpf_usdt_readarg(5, ctx, &outbound.existing);
+    bpf_probe_read_user_str(&outbound.conn.addr, sizeof(outbound.conn.addr), (void *) address_pointer);
+    bpf_probe_read_user_str(&outbound.conn.type, sizeof(outbound.conn.type), (void *) conn_type_pointer);
+    outbound_connections.perf_submit(ctx, &outbound, sizeof(outbound));
+    return 0;
+};
+
+BPF_PERF_OUTPUT(evicted_inbound_connections);
+int trace_evicted_inbound_connection(struct pt_regs *ctx) {
+    struct ClosedConnection evicted = {};
+    uint64_t conn_type_pointer;
+    uint64_t address_pointer;
+    bpf_usdt_readarg(1, ctx, &evicted.conn.id);
+    bpf_usdt_readarg(2, ctx, &address_pointer);
+    bpf_usdt_readarg(3, ctx, &conn_type_pointer);
+    bpf_usdt_readarg(4, ctx, &evicted.conn.network);
+    bpf_usdt_readarg(5, ctx, &evicted.time_established);
+    bpf_probe_read_user_str(&evicted.conn.addr, sizeof(evicted.conn.addr), (void *) address_pointer);
+    bpf_probe_read_user_str(&evicted.conn.type, sizeof(evicted.conn.type), (void *) conn_type_pointer);
+    evicted_inbound_connections.perf_submit(ctx, &evicted, sizeof(evicted));
+    return 0;
+};
+
+BPF_PERF_OUTPUT(misbehaving_connections);
+int trace_misbehaving_connection(struct pt_regs *ctx) {
+    struct MisbehavingConnection misbehaving = {};
+    uint64_t message_pointer;
+    bpf_usdt_readarg(1, ctx, &misbehaving.id);
+    bpf_usdt_readarg(2, ctx, &message_pointer);
+    bpf_probe_read_user_str(&misbehaving.message, sizeof(misbehaving.message), (void *) message_pointer);
+    misbehaving_connections.perf_submit(ctx, &misbehaving, sizeof(misbehaving));
+    return 0;
+};
+
+BPF_PERF_OUTPUT(closed_connections);
+int trace_closed_connection(struct pt_regs *ctx) {
+    struct ClosedConnection closed = {};
+    uint64_t conn_type_pointer;
+    uint64_t address_pointer;
+    bpf_usdt_readarg(1, ctx, &closed.conn.id);
+    bpf_usdt_readarg(2, ctx, &address_pointer);
+    bpf_usdt_readarg(3, ctx, &conn_type_pointer);
+    bpf_usdt_readarg(4, ctx, &closed.conn.network);
+    bpf_usdt_readarg(5, ctx, &closed.time_established);
+    bpf_probe_read_user_str(&closed.conn.addr, sizeof(closed.conn.addr), (void *) address_pointer);
+    bpf_probe_read_user_str(&closed.conn.type, sizeof(closed.conn.type), (void *) conn_type_pointer);
+    closed_connections.perf_submit(ctx, &closed, sizeof(closed));
+    return 0;
+};
+"""
+
+
+class Connection(ctypes.Structure):
+    _fields_ = [
+        ("id", ctypes.c_uint64),
+        ("addr", ctypes.c_char * MAX_PEER_ADDR_LENGTH),
+        ("conn_type", ctypes.c_char * MAX_PEER_CONN_TYPE_LENGTH),
+        ("network", ctypes.c_uint32),
+    ]
+
+    def __repr__(self):
+        return f"Connection(peer={self.id}, addr={self.addr.decode('utf-8')}, conn_type={self.conn_type.decode('utf-8')}, network={self.network})"
+
+
+class NewConnection(ctypes.Structure):
+    _fields_ = [
+        ("conn", Connection),
+        ("existing", ctypes.c_uint64),
+    ]
+
+    def __repr__(self):
+        return f"NewConnection(conn={self.conn}, existing={self.existing})"
+
+
+class ClosedConnection(ctypes.Structure):
+    _fields_ = [
+        ("conn", Connection),
+        ("time_established", ctypes.c_uint64),
+    ]
+
+    def __repr__(self):
+        return f"ClosedConnection(conn={self.conn}, time_established={self.time_established})"
+
+
+class MisbehavingConnection(ctypes.Structure):
+    _fields_ = [
+        ("id", ctypes.c_uint64),
+        ("message", ctypes.c_char * MAX_MISBEHAVING_MESSAGE_LENGTH),
+    ]
+
+    def __repr__(self):
+        return f"MisbehavingConnection(id={self.id}, message={self.message})"
+
+
+class NetTracepointTest(PocketcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [[f'-maxconnections={MAX_CONNECTIONS}']]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_platform_not_linux()
+        self.skip_if_no_pocketcoind_tracepoints()
+        self.skip_if_no_python_bcc()
+        self.skip_if_no_bpf_permissions()
+
+    def run_test(self):
+        self.p2p_message_tracepoint_test()
+        self.inbound_conn_tracepoint_test()
+        self.outbound_conn_tracepoint_test()
+        self.evicted_inbound_conn_tracepoint_test()
+        self.misbehaving_conn_tracepoint_test()
+        self.closed_conn_tracepoint_test()
+
+    def p2p_message_tracepoint_test(self):
+        # Tests the net:inbound_message and net:outbound_message tracepoints
+        # See https://github.com/pocketnetteam/pocketnet.core/blob/master/doc/tracing.md#context-net
+
+        class P2PMessage(ctypes.Structure):
+            _fields_ = [
+                ("peer_id", ctypes.c_uint64),
+                ("peer_addr", ctypes.c_char * MAX_PEER_ADDR_LENGTH),
+                ("peer_conn_type", ctypes.c_char * MAX_PEER_CONN_TYPE_LENGTH),
+                ("msg_type", ctypes.c_char * MAX_MSG_TYPE_LENGTH),
+                ("msg_size", ctypes.c_uint64),
+                ("msg", ctypes.c_ubyte * MAX_MSG_DATA_LENGTH),
+            ]
+
+            def __repr__(self):
+                return f"P2PMessage(peer={self.peer_id}, addr={self.peer_addr.decode('utf-8')}, conn_type={self.peer_conn_type.decode('utf-8')}, msg_type={self.msg_type.decode('utf-8')}, msg_size={self.msg_size})"
+
+        self.log.info(
+            "hook into the net:inbound_message and net:outbound_message tracepoints")
+        ctx = USDT(pid=self.nodes[0].process.pid)
+        ctx.enable_probe(probe="net:inbound_message",
+                         fn_name="trace_inbound_message")
+        ctx.enable_probe(probe="net:outbound_message",
+                         fn_name="trace_outbound_message")
+        bpf = BPF(text=net_tracepoints_program, usdt_contexts=[ctx], debug=0, cflags=["-Wno-error=implicit-function-declaration"])
+
+        EXPECTED_INOUTBOUND_VERSION_MSG = 1
+        checked_inbound_version_msg = 0
+        checked_outbound_version_msg = 0
+        events = []
+
+        def check_p2p_message(event, is_inbound):
+            nonlocal checked_inbound_version_msg, checked_outbound_version_msg
+            if event.msg_type.decode("utf-8") == "version":
+                self.log.info(
+                    f"check_p2p_message(): {'inbound' if is_inbound else 'outbound'} {event}")
+                peer = self.nodes[0].getpeerinfo()[0]
+                msg = msg_version()
+                msg.deserialize(BytesIO(bytes(event.msg[:event.msg_size])))
+                assert_equal(peer["id"], event.peer_id, peer["id"])
+                assert_equal(peer["addr"], event.peer_addr.decode("utf-8"))
+                assert_equal(peer["connection_type"],
+                             event.peer_conn_type.decode("utf-8"))
+                if is_inbound:
+                    checked_inbound_version_msg += 1
+                else:
+                    checked_outbound_version_msg += 1
+
+        def handle_inbound(_, data, __):
+            event = ctypes.cast(data, ctypes.POINTER(P2PMessage)).contents
+            events.append((event, True))
+
+        def handle_outbound(_, data, __):
+            event = ctypes.cast(data, ctypes.POINTER(P2PMessage)).contents
+            events.append((event, False))
+
+        bpf["inbound_messages"].open_perf_buffer(handle_inbound)
+        bpf["outbound_messages"].open_perf_buffer(handle_outbound)
+
+        self.log.info("connect a P2P test node to our pocketcoind node")
+        test_node = P2PInterface()
+        self.nodes[0].add_p2p_connection(test_node)
+        bpf.perf_buffer_poll(timeout=200)
+
+        self.log.info(
+            "check receipt and content of in- and outbound version messages")
+        for event, is_inbound in events:
+            check_p2p_message(event, is_inbound)
+        assert_equal(EXPECTED_INOUTBOUND_VERSION_MSG,
+                     checked_inbound_version_msg)
+        assert_equal(EXPECTED_INOUTBOUND_VERSION_MSG,
+                     checked_outbound_version_msg)
+
+
+        bpf.cleanup()
+        test_node.peer_disconnect()
+
+    def inbound_conn_tracepoint_test(self):
+        self.log.info("hook into the net:inbound_connection tracepoint")
+        ctx = USDT(pid=self.nodes[0].process.pid)
+        ctx.enable_probe(probe="net:inbound_connection",
+                         fn_name="trace_inbound_connection")
+        bpf = BPF(text=net_tracepoints_program, usdt_contexts=[ctx], debug=0, cflags=["-Wno-error=implicit-function-declaration"])
+
+        inbound_connections = []
+        EXPECTED_INBOUND_CONNECTIONS = 2
+
+        def handle_inbound_connection(_, data, __):
+            nonlocal inbound_connections
+            event = ctypes.cast(data, ctypes.POINTER(NewConnection)).contents
+            self.log.info(f"handle_inbound_connection(): {event}")
+            inbound_connections.append(event)
+
+        bpf["inbound_connections"].open_perf_buffer(handle_inbound_connection)
+
+        self.log.info("connect two P2P test nodes to our pocketcoind node")
+        testnodes = list()
+        for _ in range(EXPECTED_INBOUND_CONNECTIONS):
+            testnode = P2PInterface()
+            self.nodes[0].add_p2p_connection(testnode)
+            testnodes.append(testnode)
+        bpf.perf_buffer_poll(timeout=200)
+
+        assert_equal(EXPECTED_INBOUND_CONNECTIONS, len(inbound_connections))
+        for inbound_connection in inbound_connections:
+            assert inbound_connection.conn.id > 0
+            assert inbound_connection.existing > 0
+            assert_equal(b'inbound', inbound_connection.conn.conn_type)
+            assert_equal(NETWORK_TYPE_UNROUTABLE, inbound_connection.conn.network)
+
+        bpf.cleanup()
+        for node in testnodes:
+            node.peer_disconnect()
+
+    def outbound_conn_tracepoint_test(self):
+        self.log.info("hook into the net:outbound_connection tracepoint")
+        ctx = USDT(pid=self.nodes[0].process.pid)
+        ctx.enable_probe(probe="net:outbound_connection",
+                         fn_name="trace_outbound_connection")
+        bpf = BPF(text=net_tracepoints_program, usdt_contexts=[ctx], debug=0, cflags=["-Wno-error=implicit-function-declaration"])
+
+        # that the handle_* function succeeds.
+        EXPECTED_OUTBOUND_CONNECTIONS = 2
+        EXPECTED_CONNECTION_TYPE = "feeler"
+        outbound_connections = []
+
+        def handle_outbound_connection(_, data, __):
+            event = ctypes.cast(data, ctypes.POINTER(NewConnection)).contents
+            self.log.info(f"handle_outbound_connection(): {event}")
+            outbound_connections.append(event)
+
+        bpf["outbound_connections"].open_perf_buffer(
+            handle_outbound_connection)
+
+        self.log.info(
+            f"connect {EXPECTED_OUTBOUND_CONNECTIONS} P2P test nodes to our pocketcoind node")
+        testnodes = list()
+        for p2p_idx in range(EXPECTED_OUTBOUND_CONNECTIONS):
+            testnode = P2PInterface()
+            self.nodes[0].add_outbound_p2p_connection(
+                testnode, p2p_idx=p2p_idx, connection_type=EXPECTED_CONNECTION_TYPE)
+            testnodes.append(testnode)
+        bpf.perf_buffer_poll(timeout=200)
+
+        assert_equal(EXPECTED_OUTBOUND_CONNECTIONS, len(outbound_connections))
+        for outbound_connection in outbound_connections:
+            assert outbound_connection.conn.id > 0
+            assert outbound_connection.existing > 0
+            assert_equal(EXPECTED_CONNECTION_TYPE, outbound_connection.conn.conn_type.decode('utf-8'))
+            assert_equal(NETWORK_TYPE_UNROUTABLE, outbound_connection.conn.network)
+
+        bpf.cleanup()
+        for node in testnodes:
+            node.peer_disconnect()
+
+    def evicted_inbound_conn_tracepoint_test(self):
+        self.log.info("hook into the net:evicted_inbound_connection tracepoint")
+        ctx = USDT(pid=self.nodes[0].process.pid)
+        ctx.enable_probe(probe="net:evicted_inbound_connection",
+                         fn_name="trace_evicted_inbound_connection")
+        bpf = BPF(text=net_tracepoints_program, usdt_contexts=[ctx], debug=0, cflags=["-Wno-error=implicit-function-declaration"])
+
+        EXPECTED_EVICTED_CONNECTIONS = 2
+        evicted_connections = []
+
+        def handle_evicted_inbound_connection(_, data, __):
+            event = ctypes.cast(data, ctypes.POINTER(ClosedConnection)).contents
+            self.log.info(f"handle_evicted_inbound_connection(): {event}")
+            evicted_connections.append(event)
+
+        bpf["evicted_inbound_connections"].open_perf_buffer(handle_evicted_inbound_connection)
+
+        self.log.info(
+            f"connect {MAX_INBOUND_CONNECTIONS + EXPECTED_EVICTED_CONNECTIONS} P2P test nodes to our pocketcoind node and expect {EXPECTED_EVICTED_CONNECTIONS} evictions")
+        testnodes = list()
+        for p2p_idx in range(MAX_INBOUND_CONNECTIONS + EXPECTED_EVICTED_CONNECTIONS):
+            testnode = P2PInterface()
+            self.nodes[0].add_p2p_connection(testnode)
+            testnodes.append(testnode)
+        bpf.perf_buffer_poll(timeout=200)
+
+        assert_equal(EXPECTED_EVICTED_CONNECTIONS, len(evicted_connections))
+        for evicted_connection in evicted_connections:
+            assert evicted_connection.conn.id > 0
+            assert evicted_connection.time_established > 0
+            assert_equal("inbound", evicted_connection.conn.conn_type.decode('utf-8'))
+            assert_equal(NETWORK_TYPE_UNROUTABLE, evicted_connection.conn.network)
+
+        bpf.cleanup()
+        for node in testnodes:
+            node.peer_disconnect()
+
+    def misbehaving_conn_tracepoint_test(self):
+        self.log.info("hook into the net:misbehaving_connection tracepoint")
+        ctx = USDT(pid=self.nodes[0].process.pid)
+        ctx.enable_probe(probe="net:misbehaving_connection",
+                         fn_name="trace_misbehaving_connection")
+        bpf = BPF(text=net_tracepoints_program, usdt_contexts=[ctx], debug=0, cflags=["-Wno-error=implicit-function-declaration"])
+
+        EXPECTED_MISBEHAVING_CONNECTIONS = 2
+        misbehaving_connections = []
+
+        def handle_misbehaving_connection(_, data, __):
+            event = ctypes.cast(data, ctypes.POINTER(MisbehavingConnection)).contents
+            self.log.info(f"handle_misbehaving_connection(): {event}")
+            misbehaving_connections.append(event)
+
+        bpf["misbehaving_connections"].open_perf_buffer(handle_misbehaving_connection)
+
+        self.log.info(
+            f"connect a misbehaving P2P test nodes to our pocketcoind node")
+        msg = msg_headers([CBlockHeader()] * (MAX_HEADERS_RESULTS + 1))
+        for _ in range(EXPECTED_MISBEHAVING_CONNECTIONS):
+            testnode = P2PInterface()
+            self.nodes[0].add_p2p_connection(testnode)
+            testnode.send_message(msg)
+            bpf.perf_buffer_poll(timeout=500)
+            testnode.peer_disconnect()
+
+        assert_equal(EXPECTED_MISBEHAVING_CONNECTIONS, len(misbehaving_connections))
+        for misbehaving_connection in misbehaving_connections:
+            assert misbehaving_connection.id > 0
+            assert len(misbehaving_connection.message) > 0
+            assert misbehaving_connection.message == b"headers message size = 2001"
+
+        bpf.cleanup()
+
+    def closed_conn_tracepoint_test(self):
+        self.log.info("hook into the net:closed_connection tracepoint")
+        ctx = USDT(pid=self.nodes[0].process.pid)
+        ctx.enable_probe(probe="net:closed_connection",
+                         fn_name="trace_closed_connection")
+        bpf = BPF(text=net_tracepoints_program, usdt_contexts=[ctx], debug=0, cflags=["-Wno-error=implicit-function-declaration"])
+
+        EXPECTED_CLOSED_CONNECTIONS = 2
+        closed_connections = []
+
+        def handle_closed_connection(_, data, __):
+            event = ctypes.cast(data, ctypes.POINTER(ClosedConnection)).contents
+            self.log.info(f"handle_closed_connection(): {event}")
+            closed_connections.append(event)
+
+        bpf["closed_connections"].open_perf_buffer(handle_closed_connection)
+
+        self.log.info(
+            f"connect {EXPECTED_CLOSED_CONNECTIONS} P2P test nodes to our pocketcoind node")
+        testnodes = list()
+        for p2p_idx in range(EXPECTED_CLOSED_CONNECTIONS):
+            testnode = P2PInterface()
+            self.nodes[0].add_p2p_connection(testnode)
+            testnodes.append(testnode)
+        for node in testnodes:
+            node.peer_disconnect()
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0)
+        bpf.perf_buffer_poll(timeout=400)
+
+        assert_equal(EXPECTED_CLOSED_CONNECTIONS, len(closed_connections))
+        for closed_connection in closed_connections:
+            assert closed_connection.conn.id > 0
+            assert_equal("inbound", closed_connection.conn.conn_type.decode('utf-8'))
+            assert_equal(0, closed_connection.conn.network)
+            assert closed_connection.time_established > 0
+
+        bpf.cleanup()
+
+if __name__ == '__main__':
+    NetTracepointTest(__file__).main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -756,6 +756,17 @@ class PocketcoinTestFramework(metaclass=PocketcoinTestMetaClass):
         for i in range(self.num_nodes):
             initialize_datadir(self.options.tmpdir, i, self.chain)
 
+    def skip_if_no_pocketcoind_tracepoints(self):
+        """Skip the running test if bitcoind has not been compiled with USDT tracepoint support."""
+        if not self.is_usdt_compiled():
+            raise SkipTest("bitcoind has not been built with USDT tracepoints enabled.")
+
+    def skip_if_no_bpf_permissions(self):
+        """Skip the running test if we don't have permissions to do BPF syscalls and load BPF maps."""
+        # check for 'root' permissions
+        if os.geteuid() != 0:
+            raise SkipTest("no permissions to use BPF (please review the tests carefully before running them with higher privileges)")
+
     def skip_if_no_py3_zmq(self):
         """Attempt to import the zmq package and skip the test if the import fails."""
         try:
@@ -814,6 +825,10 @@ class PocketcoinTestFramework(metaclass=PocketcoinTestMetaClass):
     def is_wallet_tool_compiled(self):
         """Checks whether pocketcoin-wallet was compiled."""
         return self.config["components"].getboolean("ENABLE_WALLET_TOOL")
+
+    def is_usdt_compiled(self):
+        """Checks whether the USDT tracepoints were compiled."""
+        return self.config["components"].getboolean("ENABLE_USDT_TRACEPOINTS")
 
     def is_zmq_compiled(self):
         """Checks whether the zmq module was compiled."""

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -756,16 +756,33 @@ class PocketcoinTestFramework(metaclass=PocketcoinTestMetaClass):
         for i in range(self.num_nodes):
             initialize_datadir(self.options.tmpdir, i, self.chain)
 
+    def skip_if_no_python_bcc(self):
+        """Attempt to import the bcc package and skip the tests if the import fails."""
+        try:
+            import bcc  # type: ignore[import] # noqa: F401
+        except ImportError:
+            raise SkipTest("bcc python module not available")
+
     def skip_if_no_pocketcoind_tracepoints(self):
-        """Skip the running test if bitcoind has not been compiled with USDT tracepoint support."""
+        """Skip the running test if pocketcoind has not been compiled with USDT tracepoint support."""
         if not self.is_usdt_compiled():
-            raise SkipTest("bitcoind has not been built with USDT tracepoints enabled.")
+            raise SkipTest("pocketcoind has not been built with USDT tracepoints enabled.")
 
     def skip_if_no_bpf_permissions(self):
         """Skip the running test if we don't have permissions to do BPF syscalls and load BPF maps."""
         # check for 'root' permissions
         if os.geteuid() != 0:
             raise SkipTest("no permissions to use BPF (please review the tests carefully before running them with higher privileges)")
+
+    def skip_if_platform_not_linux(self):
+        """Skip the running test if we are not on a Linux platform"""
+        if platform.system() != "Linux":
+            raise SkipTest("not on a Linux system")
+
+    def skip_if_platform_not_posix(self):
+        """Skip the running test if we are not on a POSIX platform"""
+        if os.name != 'posix':
+            raise SkipTest("not on a POSIX system")
 
     def skip_if_no_py3_zmq(self):
         """Attempt to import the zmq package and skip the test if the import fails."""

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -160,6 +160,7 @@ BASE_SCRIPTS = [
     'wallet_reorgsrestore.py',
     'interface_http.py',
     'interface_rpc.py',
+    'interface_usdt_mempool.py',
     'rpc_psbt.py',
     'rpc_psbt.py --descriptors',
     'rpc_users.py',


### PR DESCRIPTION
This PR adds documentation for User-Space, Statically Defined Tracing (USDT) as well as tracepoints (including documentation and usage examples).

User-space, Statically Defined Tracing (USDT) allows for more observability during development, debugging, code review, and production usage. The tracepoints make it possible to keep track of custom statistics and enable detailed monitoring of otherwise hidden internals and have little to no performance impact when unused. Linux kernels (4.x or newer) can hook into the tracepoints and execute [eBPF](https://ebpf.io/) programs in a kernel VM once the tracepoint is called.

This PR includes, for example, tracepoints for in- and outbound P2P messages.

The two main [eBPF](https://ebpf.io/) front-ends with support for USDT are [bpftrace](https://github.com/iovisor/bpftrace) an [BPF Compiler Collection (BCC)](https://github.com/iovisor/bcc). BCC is used for complex tools and daemons and bpftrace is preferred for one-liners and shorter scripts. Example tracing scripts for both are provided with this PR.

This PR adds following tracepoints:
* net:inbound_message
* net:outbound_message
* net:inbound_connection
* net:outbound_connection
* net:closed_connnection
* net:evicted_inbound_connection
* net:misbehaving_connection
* valildation:block_connected
* mempool:added
* mempool:removed
* mempool:replaced
* mempool:rejected

See doc/tracing.md and contrib/tracing/ for documentation and example tracing scripts.