### PR TITLE
Add GetGroups method to BarteronRepository and corresponding RPC handler

### DIFF
--- a/src/pocketdb/repositories/web/BarteronRepository.h
+++ b/src/pocketdb/repositories/web/BarteronRepository.h
@@ -21,6 +21,7 @@ namespace PocketDb
         string Language = "";
         vector<int> Tags;
         vector<string> Location;
+        int LocationGroup = 1;
         int64_t PriceMax = -1;
         int64_t PriceMin = -1;
         string Search = "";
@@ -58,6 +59,7 @@ namespace PocketDb
         map<string, BarteronAccountAdditionalInfo> GetAccountsAdditionalInfo(const vector<string>& txids);
         vector<string> GetAccountOffersIds(const string& address);
         vector<string> GetFeed(const BarteronOffersFeedDto& args);
+        UniValue GetGroups(const BarteronOffersFeedDto& args);
         vector<string> GetDeals(const BarteronOffersDealDto& args);
         map<string, vector<string>> GetComplexDeal(const BarteronOffersComplexDealDto& args);
     };

--- a/src/pocketdb/web/BarteronRpc.h
+++ b/src/pocketdb/web/BarteronRpc.h
@@ -16,6 +16,7 @@ namespace PocketWeb::PocketWebRpc
     RPCHelpMan GetBarteronOffersByRootTxHashes();
     RPCHelpMan GetBarteronOffersByAddress();
     RPCHelpMan GetBarteronFeed();
+    RPCHelpMan GetBarteronGroups();
     RPCHelpMan GetBarteronDeals();
     RPCHelpMan GetBarteronOffersDetails();
     RPCHelpMan GetBarteronComplexDeals();

--- a/src/pocketdb/web/PocketRpc.cpp
+++ b/src/pocketdb/web/PocketRpc.cpp
@@ -145,13 +145,12 @@ static const CRPCCommand commands[] =
     {"barteron",       "getbarteronoffersbyroottxhashes",  &GetBarteronOffersByRootTxHashes,{"hashes"}},
     {"barteron",       "getbarteronoffersbyaddress",       &GetBarteronOffersByAddress,     {"address"}},
     {"barteron",       "getbarteronfeed",                  &GetBarteronFeed,                {}},
-    // TODO (rpc): fixup params
+    {"barteron",       "getbarterongroups",                &GetBarteronGroups,              {}},
     {"barteron",       "getbarterondeals",                 &GetBarteronDeals,               {"hash"}},
     {"barteron",       "getbarteronoffersdetails",         &GetBarteronOffersDetails,       {"hash"}},
     {"barteron",       "getbarteroncomplexdeals",          &GetBarteronComplexDeals,        {"hash"}},
 
     // Apps
-    // TODO (rpc): fixup params
     {"apps",           "getapps",                          &GetApps,                        { }},
     {"apps",           "getappscores",                     &GetAppScores,                   { }},
     {"apps",           "getappcomments",                   &GetAppComments,                 { }},


### PR DESCRIPTION
- Implemented GetGroups method in BarteronRepository.cpp to retrieve groups based on various filters including language, price range, tags, and location.
- Updated BarteronRepository.h to declare the new GetGroups method.
- Added GetBarteronGroups RPC handler in BarteronRpc.cpp to facilitate group retrieval via RPC.
- Updated RPC command registration in PocketRpc.cpp to include the new getbarterongroups command.

## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [ ] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- [...]

## Other comments:

...
