### PR TITLE
Update moderation flag checkpoint for PIP 112

### DIFF
--- a/doc/pips.md
+++ b/doc/pips.md
@@ -138,7 +138,7 @@ Changes:
 ## `PIP 112`: Moderation flag check block depth 
 
 Fork start at:
-- Main net: 3291900
+- Main net: 3291950
 - Test net: 3468628
 
 Changes:

--- a/src/pocketdb/consensus/moderation/Flag.hpp
+++ b/src/pocketdb/consensus/moderation/Flag.hpp
@@ -173,7 +173,7 @@ namespace PocketConsensus
         {
             Checkpoint({       0,       0, -1, make_shared<ModerationFlagConsensus>() });
             Checkpoint({ 3291900, 3373650, -1, make_shared<ModerationFlagConsensus_pip_109>() });
-            Checkpoint({ 3291900, 3468628,  0, make_shared<ModerationFlagConsensus_pip_112>() });
+            Checkpoint({ 3291950, 3468628,  0, make_shared<ModerationFlagConsensus_pip_112>() });
         }
     };
 


### PR DESCRIPTION
- Adjusted the main net fork height for PIP 112 from 3291900 to 3291950 in both documentation and source code.
- This change ensures consistency in the moderation flag check block depth across relevant files.

## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [ ] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- [...]

## Other comments:

...
