### PR TITLE
fix: remove redundant cross join in moderation query

### DIFF
--- a/src/pocketdb/repositories/web/ModerationRepository.cpp
+++ b/src/pocketdb/repositories/web/ModerationRepository.cpp
@@ -194,8 +194,6 @@ namespace PocketDb
                         c.RowId = f.RegId2
                     cross join Chain cc on
                         cc.TxId = c.RowId
-                    cross join First fc on
-                        fc.TxId = cc.TxId
                     cross join Transactions u on
                         u.Type = 100 and u.RegId1 = f.RegId3
                     cross join First fu on


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For consensus use "consensus:" prefix, e.g. "consensus: increasing Scores limits"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feature:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"
  - For workflow process use "workflow:" prefix, e.g. "workflow: added PR template"

Use this prefixes for PR branches also, eg:
workflow/pr-template

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [ ] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- [...]

## Other comments:

...
