### PR TITLE
feat: auto abandon orphan stakes

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -421,10 +421,10 @@ static RPCHelpMan stakeblock()
             {"count", RPCArg::Type::NUM, /* default */ "1", "Count of new blocks."},
             {"wallet_name", RPCArg::Type::STR, /* default */ "", "Count of new blocks."},
         },
-        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCResult{RPCResult::Type::STR, "", "The txid of the stake transaction."},
         RPCExamples{
-            HelpExampleCli("stake", "") +
-            HelpExampleRpc("stake", "")
+            HelpExampleCli("stakeblock", "1") +
+            HelpExampleRpc("stakeblock", "1")
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
     {
@@ -440,11 +440,12 @@ static RPCHelpMan stakeblock()
         std::string wallet_name = "";
         if (request.params.size() > 1 && request.params[1].isStr())
             wallet_name = request.params[1].get_str();
-        
-        if (!Staker::getInstance()->stake(request.context, Params(), num_blocks, wallet_name))
+
+        std::string stake_txid;
+        if (!Staker::getInstance()->stake(request.context, Params(), stake_txid, num_blocks, wallet_name))
             throw JSONRPCError(RPC_MISC_ERROR, "Stake failed, see debug.log");
         
-        return NullUniValue;
+        return stake_txid;
     }};
 }
 

--- a/src/staker.cpp
+++ b/src/staker.cpp
@@ -203,7 +203,7 @@ void Staker::worker(const util::Ref& context, CChainParams const& chainparams, s
     LogPrintf("Staker worker thread stopped for \"%s\"\n", wallet->GetDisplayName());
 }
 
-bool Staker::stake(const util::Ref& context, CChainParams const& chainparams, unsigned int blocks, const std::string& wallet_name)
+bool Staker::stake(const util::Ref& context, CChainParams const& chainparams, std::string& stake_txid, unsigned int blocks, const std::string& wallet_name)
 {
     const auto& node = EnsureNodeContext(context);
     CHECK_NONFATAL(node.mempool); // Mempool should be always available here
@@ -239,7 +239,10 @@ bool Staker::stake(const util::Ref& context, CChainParams const& chainparams, un
                 {
                     // Extend pocketBlock with coinStake transaction
                     if (auto[ok, ptx] = PocketServices::Serializer::DeserializeTransaction(block->vtx[1]); ok)
+                    {
                         blocktemplate->pocketBlock->emplace_back(ptx);
+                        stake_txid = *ptx->GetHash();
+                    }
 
                     blockSigned = CheckStake(block, blocktemplate->pocketBlock, wallet, chainparams, *node.chainman, *node.mempool);
                 }

--- a/src/staker.h
+++ b/src/staker.h
@@ -39,7 +39,7 @@ public:
     void run(const util::Ref& context, CChainParams const&, boost::thread_group&);
 
     void worker(const util::Ref& context, CChainParams const&, std::string const& walletName);
-    bool stake(const util::Ref& context, CChainParams const& chainparams, unsigned int blocks = 1, const std::string& wallet_name = "");
+    bool stake(const util::Ref& context, CChainParams const& chainparams, std::string& stake_txid, unsigned int blocks = 1, const std::string& wallet_name = "");
 
     bool signBlock(std::shared_ptr<CBlock>, std::shared_ptr<CWallet>, int64_t);
     bool sign(std::shared_ptr<CBlock> block, CMutableTransaction& txCoinStake, std::vector<CTransactionRef>& vtx, LegacyScriptPubKeyMan& legacyKeyStore, CKey& key, std::shared_ptr<CWallet> wallet);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1272,6 +1272,32 @@ void CWallet::blockDisconnected(const CBlock& block, int height)
 	for (const CTransactionRef& ptx : block.vtx) {
 		SyncTransaction(ptx, {CWalletTx::Status::UNCONFIRMED, /* block height */ 0, /* block hash */ {}, /* index */ 0});
 	}
+
+	// Call to abandon orphaned coinstakes after handling disconnections
+    AbandonOrphanedCoinstakes();
+}
+
+void CWallet::AbandonOrphanedCoinstakes()
+{
+	LOCK(cs_wallet);
+
+    // m_last_block_processed_height can be < 0
+    // when loading the wallet during a reindex. Do nothing in that case.
+    if (m_last_block_processed_height < 0) {
+        return;
+    }
+
+    for (std::pair<const uint256, CWalletTx>& item : mapWallet) {
+        const uint256& wtxid = item.first;
+        CWalletTx& wtx = item.second;
+        assert(wtx.GetHash() == wtxid);
+        if (wtx.GetDepthInMainChain() == 0 && !wtx.isAbandoned() && wtx.IsCoinStake()) {
+            LogPrint(BCLog::WALLET, "Abandoning coinstake wtx %s\n", wtx.GetHash().ToString());
+            if (!AbandonTransaction(wtxid)) {
+                LogPrint(BCLog::WALLET, "Failed to abandon coinstake tx %s\n", wtx.GetHash().ToString());
+            }
+        }
+    }
 }
 
 void CWallet::updatedBlockTip()

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -922,6 +922,8 @@ public:
     void transactionAddedToMempool(const CTransactionRef& tx, uint64_t mempool_sequence) override;
     void blockConnected(const CBlock& block, int height) override;
     void blockDisconnected(const CBlock& block, int height) override;
+    /* Function that will remove potentially abandoned coinstakes, returning the input to the wallet. */
+    void AbandonOrphanedCoinstakes();
     void updatedBlockTip() override;
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
 

--- a/test/functional/pocketnet/abandon_orphan_stakes.py
+++ b/test/functional/pocketnet/abandon_orphan_stakes.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2022 The Bitcoin Core developers
+# Copyright (c) 2018-2023 The Pocketnet Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+An Auto Abandon Orphan Stakes functional test
+Launch this with command from 'test/functional/pocketnet' directory
+"""
+
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+# Imports should be in PEP8 ordering (std library first, then third party
+# libraries then local imports).
+from test_framework.test_framework import PocketcoinTestFramework
+from test_framework.util import assert_equal
+
+# Pocketnet framework
+from framework.helpers import rollback_node, restoreTo
+from framework.models import *
+
+from framework.chain_builder import ChainBuilder
+
+DEFAULT_FEED_PARAMS = [0, "", 20, "", [], [], [], [], [], ""]
+
+class AbandonOrphanStakesTest(PocketcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-debug=consensus", "-debug=wallet"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+        builder = ChainBuilder(node, self.log)
+        builder.build_init(accounts_num=0, moderators_num=0)
+
+        # ---------------------------------------------------------------------------------
+        self.log.info("General check stake, invalidate and reconsider")
+
+        # Start balance
+        b0 = node.getwalletinfo()['ttl_balance']
+
+        # Generate new stake
+        stake_id = node.stakeblock(1)
+        test_block_hash = node.getbestblockhash()
+
+        # New stake is not abandoned
+        stake_0 = [s for s in node.listtransactions("*", 2000)['txs'] if s['txid'] == stake_id and s['vout'] == 0][0]
+        assert_equal(stake_0['abandoned'], False)
+
+        # Balance after new stake
+        b1 = node.getwalletinfo()['ttl_balance']
+        assert(b1 != b0)
+
+        # Invalidate stake for testing auto abandon
+        node.invalidateblock(test_block_hash)
+
+        # Stake is abandoned
+        stake_1 = [s for s in node.listtransactions("*", 2000)['txs'] if s['txid'] == stake_id and s['vout'] == 0][0]
+        assert_equal(stake_1['abandoned'], True)
+
+        # Balance after invalidation should be the same as before stake
+        b2 = node.getwalletinfo()['ttl_balance']
+        assert_equal(b2, b0)
+
+        # Reconsider stake for testing auto rollback abandon status and restore balance
+        node.reconsiderblock(test_block_hash)
+
+        # Stake is not abandoned
+        stake_2 = [s for s in node.listtransactions("*", 2000)['txs'] if s['txid'] == stake_id and s['vout'] == 0][0]
+        assert_equal(stake_2['abandoned'], False)
+
+        # Balance after rollback should be the same as after stake
+        b3 = node.getwalletinfo()['ttl_balance']
+        assert_equal(b3, b1)
+
+if __name__ == "__main__":
+    AbandonOrphanStakesTest().main()

--- a/test/functional/pocketnet/framework/chain_builder.py
+++ b/test/functional/pocketnet/framework/chain_builder.py
@@ -48,11 +48,13 @@ class ChainBuilder:
         info = self._node.public().getaddressinfo(self.node_address)
         self.log.info(f"Node balance: {info}")
 
-        self.log.info(f"Generate {accounts_num or self.ACCOUNT_NUM} account addresses")
-        self._accounts = generate_accounts(self._node, self.node_address, accounts_num or self.ACCOUNT_NUM)
+        if accounts_num > 0:
+            self.log.info(f"Generate {accounts_num or self.ACCOUNT_NUM} account addresses")
+            self._accounts = generate_accounts(self._node, self.node_address, accounts_num or self.ACCOUNT_NUM)
 
-        self.log.info(f"Generate {moderators_num or self.ACCOUNT_NUM} moderator addresses")
-        self._moders = generate_accounts(self._node, self.node_address, moderators_num or self.ACCOUNT_NUM, is_moderator=True)
+        if moderators_num > 0:
+            self.log.info(f"Generate {moderators_num or self.ACCOUNT_NUM} moderator addresses")
+            self._moders = generate_accounts(self._node, self.node_address, moderators_num or self.ACCOUNT_NUM, is_moderator=True)
 
     def register_accounts(self):
         self.log.info("Register accounts")


### PR DESCRIPTION
Improve stake functionality with txid return and orphaned coinstake management

- Added automatic cleanup mechanism for orphaned coinstake transactions
- Implemented AbandonOrphanedCoinstakes method to handle orphaned stakes when blocks are disconnected
- Enhanced stakeblock RPC call to return transaction ID of stake transaction instead of null
- Fixed command examples in RPC help documentation 
- Added comprehensive test case to verify orphaned stake abandonment functionality
- Updated chain_builder framework to support initialization with zero accounts
- Fixed parameter description in stakeblock RPC help