### PR TITLE
refactor: Fix deprecation warnings when building against Qt 5.15 and pocketdb rpc

### DIFF
--- a/src/pocketdb/web/PocketTagsRpc.cpp
+++ b/src/pocketdb/web/PocketTagsRpc.cpp
@@ -49,8 +49,8 @@ namespace PocketWeb::PocketWebRpc
         }
 
         string lang = "en";
-        if (request.params.size() > 2) {
-            lang = request.params[2].get_str();
+        if (request.params.size() > 3) {
+            lang = request.params[3].get_str();
         }
 
         return request.DbConnection()->WebRpcRepoInst->GetTags(lang, pageSize, pageStart);

--- a/src/pocketdb/web/PocketTagsRpc.cpp
+++ b/src/pocketdb/web/PocketTagsRpc.cpp
@@ -30,15 +30,27 @@ namespace PocketWeb::PocketWebRpc
 
         int pageStart = 0;
         if (request.params.size() > 0)
-            ParseInt32(request.params[0].get_str(), &pageStart);
+        {
+            if (request.params[0].isNum())
+                pageStart = request.params[0].get_int();
+            else if (request.params[0].isStr() && !request.params[0].empty())
+                if (!ParseInt32(request.params[0].get_str(), &pageStart))
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Failed to parse int from string");
+        }
 
         int pageSize = 50;
         if (request.params.size() > 1)
-            ParseInt32(request.params[1].get_str(), &pageSize);
+        {
+            if (request.params[1].isNum())
+                pageSize = request.params[1].get_int();
+            else if (request.params[1].isStr() && !request.params[1].empty())
+                if (!ParseInt32(request.params[1].get_str(), &pageSize))
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Failed to parse int from string");
+        }
 
         string lang = "en";
-        if (request.params.size() > 3) {
-            lang = request.params[3].get_str();
+        if (request.params.size() > 2) {
+            lang = request.params[2].get_str();
         }
 
         return request.DbConnection()->WebRpcRepoInst->GetTags(lang, pageSize, pageStart);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -991,6 +991,28 @@ QDateTime StartOfDay(const QDate& date)
 #endif
 }
 
+bool HasPixmap(const QLabel* label)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+    return !label->pixmap(Qt::ReturnByValue).isNull();
+#else
+    return label->pixmap() != nullptr;
+#endif
+}
+
+QImage GetImage(const QLabel* label)
+{
+    if (!HasPixmap(label)) {
+        return QImage();
+    }
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+    return label->pixmap(Qt::ReturnByValue).toImage();
+#else
+    return label->pixmap()->toImage();
+#endif
+}
+
 QString MakeHtmlLink(const QString& source, const QString& link)
 {
     return QString(source).replace(

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -68,7 +68,7 @@ namespace GUIUtil {
 
 QString dateTimeStr(const QDateTime &date)
 {
-    return date.date().toString(Qt::SystemLocaleShortDate) + QString(" ") + date.toString("hh:mm");
+    return QLocale::system().toString(date.date(), QLocale::ShortFormat) + QString(" ") + date.toString("hh:mm");
 }
 
 QString dateTimeStr(qint64 nTime)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -303,7 +303,7 @@ namespace GUIUtil
     /**
      * Returns the distance in pixels appropriate for drawing a subsequent character after text.
      *
-     * In Qt 5.12 and before the QFontMetrics::width() is used and it is deprecated since Qt 13.0.
+     * In Qt 5.12 and before the QFontMetrics::width() is used and it is deprecated since Qt 5.13.
      * In Qt 5.11 the QFontMetrics::horizontalAdvance() was introduced.
      */
     int TextWidth(const QFontMetrics& fm, const QString& text);
@@ -325,7 +325,35 @@ namespace GUIUtil
      * QDate::startOfDay() was introduced in Qt 5.14.
      */
     QDateTime StartOfDay(const QDate& date);
-    
+
+    /**
+     * Returns true if pixmap has been set.
+     *
+     * QPixmap* QLabel::pixmap() is deprecated since Qt 5.15.
+     */
+    bool HasPixmap(const QLabel* label);
+    QImage GetImage(const QLabel* label);
+
+    /**
+     * Splits the string into substrings wherever separator occurs, and returns
+     * the list of those strings. Empty strings do not appear in the result.
+     *
+     * QString::split() signature differs in different Qt versions:
+     *  - QString::SplitBehavior is deprecated since Qt 5.15
+     *  - Qt::SplitBehavior was introduced in Qt 5.14
+     * If {QString|Qt}::SkipEmptyParts behavior is required, use this
+     * function instead of QString::split().
+     */
+    template <typename SeparatorType>
+    QStringList SplitSkipEmptyParts(const QString& string, const SeparatorType& separator)
+    {
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        return string.split(separator, Qt::SkipEmptyParts);
+    #else
+        return string.split(separator, QString::SkipEmptyParts);
+    #endif
+    }
+
     /**
      * Queue a function to run in an object's event loop. This can be
      * replaced by a call to the QMetaObject::invokeMethod functor overload after Qt 5.10, but

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -223,7 +223,7 @@ static ProxySetting GetProxySetting(QSettings &settings, const QString &name)
         return default_val;
     }
     // contains IP at index 0 and port at index 1
-    QStringList ip_port = settings.value(name).toString().split(":", QString::SkipEmptyParts);
+    QStringList ip_port = GUIUtil::SplitSkipEmptyParts(settings.value(name).toString(), ":");
     if (ip_port.size() == 2) {
         return {true, ip_port.at(0), ip_port.at(1)};
     } else { // Invalid: return default

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -18,7 +18,6 @@
 
 #include <QAbstractItemDelegate>
 #include <QApplication>
-#include <QDateTime>
 #include <QPainter>
 #include <QStatusTipEvent>
 

--- a/src/qt/pocketcoin.cpp
+++ b/src/qt/pocketcoin.cpp
@@ -283,7 +283,7 @@ void PocketcoinApplication::createWindow(const NetworkStyle *networkStyle)
 void PocketcoinApplication::createSplashScreen(const NetworkStyle *networkStyle)
 {
     assert(!m_splash);
-    m_splash = new SplashScreen(nullptr, networkStyle);
+    m_splash = new SplashScreen(networkStyle);
     // We don't hold a direct pointer to the splash screen after creation, but the splash
     // screen will take care of deleting itself when finish() happens.
     m_splash->show();

--- a/src/qt/pocketcoingui.cpp
+++ b/src/qt/pocketcoingui.cpp
@@ -1311,7 +1311,7 @@ void PocketcoinGUI::updateProxyIcon()
     bool proxy_enabled = clientModel->getProxyInfo(ip_port);
 
     if (proxy_enabled) {
-        if (labelProxyIcon->pixmap() == nullptr) {
+        if (!GUIUtil::HasPixmap(labelProxyIcon)) {
             QString ip_port_q = QString::fromStdString(ip_port);
             labelProxyIcon->setPixmap(platformStyle->SingleColorIcon(":/icons/proxy").pixmap(STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE));
             labelProxyIcon->setToolTip(tr("Proxy is <b>enabled</b>: %1").arg(ip_port_q));

--- a/src/qt/pocketcoingui.h
+++ b/src/qt/pocketcoingui.h
@@ -49,6 +49,7 @@ struct BlockAndHeaderTipInfo;
 QT_BEGIN_NAMESPACE
 class QAction;
 class QComboBox;
+class QDateTime;
 class QMenu;
 class QProgressBar;
 class QProgressDialog;

--- a/src/qt/qrimagewidget.cpp
+++ b/src/qt/qrimagewidget.cpp
@@ -98,15 +98,12 @@ bool QRImageWidget::setQR(const QString& data, const QString& text)
 
 QImage QRImageWidget::exportImage()
 {
-    if(!pixmap())
-        return QImage();
-    return pixmap()->toImage();
+    return GUIUtil::GetImage(this);
 }
 
 void QRImageWidget::mousePressEvent(QMouseEvent *event)
 {
-    if(event->button() == Qt::LeftButton && pixmap())
-    {
+    if (event->button() == Qt::LeftButton && GUIUtil::HasPixmap(this)) {
         event->accept();
         QMimeData *mimeData = new QMimeData;
         mimeData->setImageData(exportImage());
@@ -121,7 +118,7 @@ void QRImageWidget::mousePressEvent(QMouseEvent *event)
 
 void QRImageWidget::saveImage()
 {
-    if(!pixmap())
+    if (!GUIUtil::HasPixmap(this))
         return;
     QString fn = GUIUtil::getSaveFileName(this, tr("Save QR Code"), QString(), tr("PNG Image (*.png)"), nullptr);
     if (!fn.isEmpty())
@@ -132,14 +129,14 @@ void QRImageWidget::saveImage()
 
 void QRImageWidget::copyImage()
 {
-    if(!pixmap())
+    if (!GUIUtil::HasPixmap(this))
         return;
     QApplication::clipboard()->setImage(exportImage());
 }
 
 void QRImageWidget::contextMenuEvent(QContextMenuEvent *event)
 {
-    if(!pixmap())
+    if (!GUIUtil::HasPixmap(this))
         return;
     contextMenu->exec(event->globalPos());
 }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -176,8 +176,15 @@ void SendCoinsDialog::setModel(WalletModel *_model)
         }
         connect(ui->confTargetSelector, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &SendCoinsDialog::updateSmartFeeLabel);
         connect(ui->confTargetSelector, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &SendCoinsDialog::coinControlUpdateLabels);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+        connect(ui->groupFee, &QButtonGroup::idClicked, this, &SendCoinsDialog::updateFeeSectionControls);
+        connect(ui->groupFee, &QButtonGroup::idClicked, this, &SendCoinsDialog::coinControlUpdateLabels);
+#else
         connect(ui->groupFee, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked), this, &SendCoinsDialog::updateFeeSectionControls);
         connect(ui->groupFee, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked), this, &SendCoinsDialog::coinControlUpdateLabels);
+#endif
+
         connect(ui->customFee, &PocketcoinAmountField::valueChanged, this, &SendCoinsDialog::coinControlUpdateLabels);
         connect(ui->optInRBF, &QCheckBox::stateChanged, this, &SendCoinsDialog::updateSmartFeeLabel);
         connect(ui->optInRBF, &QCheckBox::stateChanged, this, &SendCoinsDialog::coinControlUpdateLabels);

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -25,8 +25,8 @@
 #include <QScreen>
 
 
-SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) :
-    QWidget(nullptr, f), curAlignment(0)
+SplashScreen::SplashScreen(const NetworkStyle* networkStyle)
+    : QWidget(), curAlignment(0)
 {
     // set reference point, paddings
     int paddingRight            = 50;

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -28,7 +28,7 @@ class SplashScreen : public QWidget
     Q_OBJECT
 
 public:
-    explicit SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle);
+    explicit SplashScreen(const NetworkStyle *networkStyle);
     ~SplashScreen();
     void setNode(interfaces::Node& node);
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -238,7 +238,7 @@ void TransactionView::setModel(WalletModel *_model)
         if (_model->getOptionsModel())
         {
             // Add third party transaction URLs to context menu
-            QStringList listUrls = _model->getOptionsModel()->getThirdPartyTxUrls().split("|", QString::SkipEmptyParts);
+            QStringList listUrls = GUIUtil::SplitSkipEmptyParts(_model->getOptionsModel()->getThirdPartyTxUrls(), "|");
             for (int i = 0; i < listUrls.size(); ++i)
             {
                 QString url = listUrls[i].trimmed();

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -628,7 +628,7 @@ bool BerkeleyDatabase::Backup(const std::string& strDest) const
                         return false;
                     }
 
-                    fs::copy_file(pathSrc, pathDest, fs::copy_option::overwrite_if_exists);
+                    fs::copy_file(pathSrc, pathDest, fs::copy_options::overwrite_existing);
                     LogPrintf("copied %s to %s\n", strFile, pathDest.string());
                     return true;
                 } catch (const fs::filesystem_error& e) {

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -46,7 +46,7 @@ std::vector<fs::path> ListWalletDir()
     for (auto it = fs::recursive_directory_iterator(wallet_dir, ec); it != fs::recursive_directory_iterator(); it.increment(ec)) {
         if (ec) {
             if (fs::is_directory(*it)) {
-                it.no_push();
+                it.disable_recursion_pending();
                 LogPrintf("%s: %s %s -- skipping.\n", __func__, ec.message(), it->path().string());
             } else {
                 LogPrintf("%s: %s %s\n", __func__, ec.message(), it->path().string());
@@ -63,7 +63,7 @@ std::vector<fs::path> ListWalletDir()
                 (ExistsBerkeleyDatabase(it->path()) || ExistsSQLiteDatabase(it->path()))) {
                 // Found a directory which contains wallet.dat btree file, add it as a wallet.
                 paths.emplace_back(path);
-            } else if (it.level() == 0 && it->symlink_status().type() == fs::regular_file && ExistsBerkeleyDatabase(it->path())) {
+            } else if (it.depth() == 0 && it->symlink_status().type() == fs::regular_file && ExistsBerkeleyDatabase(it->path())) {
                 if (it->path().filename() == "wallet.dat") {
                     // Found top-level wallet.dat btree file, add top level directory ""
                     // as a wallet.
@@ -78,7 +78,7 @@ std::vector<fs::path> ListWalletDir()
             }
         } catch (const std::exception& e) {
             LogPrintf("%s: Error scanning %s: %s\n", __func__, it->path().string(), e.what());
-            it.no_push();
+            it.disable_recursion_pending();
         }
     }
 


### PR DESCRIPTION
- refactor: Fix deprecation warnings when building against Qt 5.15 (backported from bitcoin-core/gui#46)
- pocketdb: gettags rpc parameters processing fixes
