### PR TITLE
feat: getsubscribeschannels RPC method

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,74 +197,8 @@ jobs:
           name: MacOS_arm64
           path: ./out/*
 
-  build-macos-amd64:
-    runs-on: macos-15-intel
-    needs: prepare
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v4
-      - name: Install general dependencies
-        run: |
-          brew install automake make miniupnpc protobuf qrencode librsvg python-setuptools berkeley-db@4
-      - name: Cache depends
-        id: cache-depends
-        uses: actions/cache@v4
-        with:
-          path: depends/x86_64-apple-darwin22.6.0
-          key: macos-amd64-depends-${{ hashFiles('depends/Makefile', 'depends/funcs.mk', 'depends/packages/**/*.mk') }}
-          restore-keys: macos-amd64-depends-
-      - name: Build depends
-        if: steps.cache-depends.outputs.cache-hit != 'true'
-        run: cd depends && make && cd ..
-      - name: Configure
-        run: |
-          ./autogen.sh
-          ./configure --prefix=$PWD/depends/x86_64-apple-darwin22.6.0
-      - name: Make
-        run: |
-          make -j4
-          make deploy
-      - name: Sign App
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
-          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
-          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
-        run: |
-          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain 
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-          security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-          /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime dist/Pocketcoin-Qt.app -v
-      - name: Notarize App
-        env:
-          PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
-          PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
-          PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
-        run: |
-          xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
-          ditto -c -k --keepParent "dist/Pocketcoin-Qt.app" "notarization.zip"
-          xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
-          xcrun stapler staple "dist/Pocketcoin-Qt.app"
-      - name: Build DMG image
-        run: |
-          ./contrib/macdeploy/createdmg Pocketcoin-Qt.app Pocketnet-Core
-      - name: Prepare output binaries
-        run: |
-          VERSION=${{ needs.prepare.outputs.version }}
-          mkdir ./out/
-          cp ./src/pocketcoind ./out/pocketnetcore_${VERSION}_macos_x64_daemon.bin
-          cp ./Pocketnet-Core.dmg ./out/pocketnetcore_${VERSION}_macos_x64_setup.dmg
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: MacOS_x64
-          path: ./out/*
-
   deploy-binaries:
-    needs: [ build-macos-arm64, build-macos-amd64, build-linux, build-windows ]
+    needs: [ build-macos-arm64, build-linux, build-windows ]
     runs-on: dev.core
     steps:
       - name: Download artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,8 +197,75 @@ jobs:
           name: MacOS_arm64
           path: ./out/*
 
+  build-macos-amd64:
+    runs-on: macos-13
+    needs: prepare
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+      - name: Install general dependencies
+        run: |
+          brew install automake make miniupnpc protobuf qrencode librsvg python-setuptools berkeley-db@4
+          pip3 install setuptools
+      - name: Cache depends
+        id: cache-depends
+        uses: actions/cache@v4
+        with:
+          path: depends/x86_64-apple-darwin22.6.0
+          key: macos-amd64-depends-${{ hashFiles('depends/Makefile', 'depends/funcs.mk', 'depends/packages/**/*.mk') }}
+          restore-keys: macos-amd64-depends-
+      - name: Build depends
+        if: steps.cache-depends.outputs.cache-hit != 'true'
+        run: cd depends && make && cd ..
+      - name: Configure
+        run: |
+          ./autogen.sh
+          ./configure --prefix=$PWD/depends/x86_64-apple-darwin22.6.0
+      - name: Make
+        run: |
+          make -j4
+          make deploy
+      - name: Sign App
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
+          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+        run: |
+          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain 
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+          security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+          /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime dist/Pocketcoin-Qt.app -v
+      - name: Notarize App
+        env:
+          PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+          PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+          PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+        run: |
+          xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
+          ditto -c -k --keepParent "dist/Pocketcoin-Qt.app" "notarization.zip"
+          xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+          xcrun stapler staple "dist/Pocketcoin-Qt.app"
+      - name: Build DMG image
+        run: |
+          ./contrib/macdeploy/createdmg Pocketcoin-Qt.app Pocketnet-Core
+      - name: Prepare output binaries
+        run: |
+          VERSION=${{ needs.prepare.outputs.version }}
+          mkdir ./out/
+          cp ./src/pocketcoind ./out/pocketnetcore_${VERSION}_macos_x64_daemon.bin
+          cp ./Pocketnet-Core.dmg ./out/pocketnetcore_${VERSION}_macos_x64_setup.dmg
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: MacOS_x64
+          path: ./out/*
+
   deploy-binaries:
-    needs: [ build-macos-arm64, build-linux, build-windows ]
+    needs: [ build-macos-arm64, build-macos-amd64, build-linux, build-windows ]
     runs-on: dev.core
     steps:
       - name: Download artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
           path: ./out/*
 
   build-macos-amd64:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs: prepare
     steps:
       - name: Check out Git repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,6 @@ jobs:
       - name: Install general dependencies
         run: |
           brew install automake make miniupnpc protobuf qrencode librsvg python-setuptools berkeley-db@4
-          pip3 install setuptools
       - name: Cache depends
         id: cache-depends
         uses: actions/cache@v4

--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -6864,6 +6864,135 @@ namespace PocketDb
         return result;
     }
 
+    UniValue WebRpcRepository::GetSubscribesChannels(
+        const string& address,
+        int topHeight,
+        int pageStart,
+        int pageSize,
+        const vector<int>& contentTypes
+    )
+    {
+        UniValue result(UniValue::VARR);
+
+        SqlTransaction(
+            __func__,
+            [&]() -> Stmt& {
+                return Sql(R"sql(
+                    with
+                        addr as (
+                            select RowId as id from Registry where String = ?
+                        ),
+                        height as (
+                            select ? as value
+                        ),
+                        subs_with_content as (
+                            select
+                                s.RegId2 as author_id,
+                                (
+                                    select ct.Uid
+                                    from Transactions t indexed by Transactions_Type_RegId1_RegId2_RegId3
+                                    cross join Last lt on lt.TxId = t.RowId
+                                    cross join Chain ct on ct.TxId = t.RowId and ct.Height <= height.value
+                                    where t.Type in ( )sql" + join(vector<string>(contentTypes.size(), "?"), ",") + R"sql( )
+                                        and t.RegId1 = s.RegId2
+                                    order by ct.Uid desc
+                                    limit 1
+                                ) as last_content_uid
+                            from
+                                addr, height
+                            cross join
+                                Transactions s indexed by Transactions_Type_RegId1_RegId2_RegId3 on
+                                    s.Type in (302, 303) and
+                                    s.RegId1 = addr.id
+                            cross join
+                                Last ls on ls.TxId = s.RowId
+                            cross join
+                                Chain cs on cs.TxId = s.RowId and cs.Height <= height.value
+                        )
+                    select
+                        (select r.String from Registry r where r.RowId = swc.author_id) as address,
+                        p.String2 as name,
+                        p.String3 as avatar,
+                        (select r.String from Registry r where r.RowId = ct.RegId2) as root_txid,
+                        ct.Type as content_type,
+                        cp.String2 as caption,
+                        substr(cp.String3, 1, 200) as message,
+                        ifnull(ctr.Time, ct.Time) as content_time,
+                        cc.Height as content_height,
+                        ifnull((
+                            select sum(scr.Int1)
+                            from Transactions scr indexed by Transactions_Type_RegId2_RegId1
+                            cross join Chain cscr on cscr.TxId = scr.RowId
+                            where scr.Type = 300 and scr.RegId2 = ct.RegId2
+                        ), 0) as score_sum,
+                        (
+                            select count()
+                            from Transactions scr indexed by Transactions_Type_RegId2_RegId1
+                            cross join Chain cscr on cscr.TxId = scr.RowId
+                            where scr.Type = 300 and scr.RegId2 = ct.RegId2
+                        ) as score_cnt,
+                        (
+                            select count()
+                            from Transactions cmt indexed by Transactions_Type_RegId3_RegId1
+                            cross join Last lcmt on lcmt.TxId = cmt.RowId
+                            cross join Chain ccmt on ccmt.TxId = cmt.RowId
+                            where cmt.Type in (204, 205, 206) and cmt.RegId3 = ct.RegId2
+                        ) as comments_cnt
+                    from subs_with_content swc
+                    cross join Transactions u indexed by Transactions_Type_RegId1_RegId2_RegId3 on
+                        u.Type in (100, 170) and u.RegId1 = swc.author_id
+                    cross join Last lu on lu.TxId = u.RowId
+                    cross join Payload p on p.TxId = u.RowId
+                    cross join Chain cc on cc.Uid = swc.last_content_uid
+                    cross join Transactions ct on ct.RowId = cc.TxId
+                    left join Transactions ctr on ctr.RowId = ct.RegId2
+                    left join Payload cp on cp.TxId = ct.RowId
+                    where swc.last_content_uid is not null
+                    order by swc.last_content_uid desc
+                    limit ? offset ?
+                )sql")
+                .Bind(
+                    address,
+                    topHeight,
+                    contentTypes,
+                    pageSize,
+                    pageStart
+                );
+            },
+            [&] (Stmt& stmt) {
+                stmt.Select([&](Cursor& cursor) {
+                    while (cursor.Step())
+                    {
+                        UniValue channel(UniValue::VOBJ);
+                        UniValue lastContent(UniValue::VOBJ);
+
+                        int ii = 0;
+                        cursor.Collect<string>(ii++, channel, "address");
+                        cursor.Collect<string>(ii++, channel, "name");
+                        cursor.Collect<string>(ii++, channel, "avatar");
+
+                        cursor.Collect<string>(ii++, lastContent, "txid");
+                        cursor.Collect(ii++, [&](int value) {
+                            lastContent.pushKV("type", TransactionHelper::TxStringType((TxType) value));
+                        });
+                        cursor.Collect<string>(ii++, lastContent, "caption");
+                        cursor.Collect<string>(ii++, lastContent, "message");
+                        cursor.Collect<int64_t>(ii++, lastContent, "time");
+                        cursor.Collect<int>(ii++, lastContent, "height");
+                        cursor.Collect<int>(ii++, lastContent, "scoreSum");
+                        cursor.Collect<int>(ii++, lastContent, "scoreCnt");
+                        cursor.Collect<int>(ii++, lastContent, "comments");
+
+                        channel.pushKV("lastContent", lastContent);
+                        result.push_back(channel);
+                    }
+                });
+            }
+        );
+
+        return result;
+    }
+
     // ------------------------------------------------------
 
     vector<int64_t> WebRpcRepository::GetRandomContentIds(const string& lang, int count, int height)

--- a/src/pocketdb/repositories/web/WebRpcRepository.h
+++ b/src/pocketdb/repositories/web/WebRpcRepository.h
@@ -181,6 +181,14 @@ namespace PocketDb
 
         UniValue GetsubsciptionsGroupedByAuthors(const string& address, const string& addressPagination, int nHeight, int countOutOfUsers, int countOutOfcontents, int badReputationLimit);
 
+        UniValue GetSubscribesChannels(
+            const string& address,
+            int topHeight,
+            int pageStart,
+            int pageSize,
+            const vector<int>& contentTypes
+        );
+
     private:
         int cntBlocksForResult = 300;
         int cntPrevPosts = 5;

--- a/src/pocketdb/web/PocketContentRpc.cpp
+++ b/src/pocketdb/web/PocketContentRpc.cpp
@@ -1666,4 +1666,65 @@ namespace PocketWeb::PocketWebRpc
                           },
         };
     }
+
+    RPCHelpMan GetSubscribesChannels()
+    {
+        return RPCHelpMan{"getsubscribeschannels",
+                          "\nReturns subscriptions list with last content for each author (channel-style feed).\n",
+                          {
+                                  {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "User address whose subscriptions to fetch"},
+                                  {"topHeight", RPCArg::Type::NUM, RPCArg::Optional::NO, "Top block height"},
+                                  {"pageStart", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Offset for pagination (default: 0)"},
+                                  {"pageSize", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Number of records (default: 20, max: 50)"},
+                                  {"contentTypes", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "Content types filter (default: [200,201,202,209,210])",
+                                      {
+                                          {"contentType", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Content type code"},
+                                      }
+                                  }
+                          },
+                          {
+                              // TODO (rpc): provide return description
+                          },
+                          RPCExamples{
+                                  HelpExampleCli("getsubscribeschannels", "\"PktAddress\" 1000000 0 10") +
+                                  HelpExampleRpc("getsubscribeschannels", "\"PktAddress\", 1000000, 0, 10")
+                          },
+                          [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+                          {
+                              if (request.params.empty() || request.params.size() < 2)
+                                  throw JSONRPCError(RPC_INVALID_PARAMS, "address and topHeight are required");
+
+                              string address = request.params[0].get_str();
+                              int topHeight = request.params[1].get_int();
+                              int pageStart = 0;
+                              int pageSize = 20;
+                              vector<int> contentTypes = {200, 201, 202, 209, 210};
+
+                              if (request.params.size() > 2 && request.params[2].isNum())
+                                  pageStart = request.params[2].get_int();
+
+                              if (request.params.size() > 3 && request.params[3].isNum())
+                                  pageSize = std::min(request.params[3].get_int(), 50);
+
+                              if (request.params.size() > 4 && request.params[4].isArray())
+                              {
+                                  contentTypes.clear();
+                                  UniValue ctArray = request.params[4].get_array();
+                                  for (unsigned int i = 0; i < ctArray.size(); i++)
+                                  {
+                                      if (ctArray[i].isNum())
+                                          contentTypes.push_back(ctArray[i].get_int());
+                                  }
+                              }
+
+                              UniValue channels = request.DbConnection()->WebRpcRepoInst->GetSubscribesChannels(
+                                      address, topHeight, pageStart, pageSize, contentTypes);
+
+                              UniValue result(UniValue::VOBJ);
+                              result.pushKV("height", topHeight);
+                              result.pushKV("channels", channels);
+                              return result;
+                          },
+        };
+    }
 }

--- a/src/pocketdb/web/PocketContentRpc.h
+++ b/src/pocketdb/web/PocketContentRpc.h
@@ -35,6 +35,7 @@ namespace PocketWeb::PocketWebRpc
     RPCHelpMan GetActivities();
     RPCHelpMan GetNotificationsSummary();
     RPCHelpMan GetsubsciptionsGroupedByAuthors();
+    RPCHelpMan GetSubscribesChannels();
 }
 
 #endif //SRC_POCKETDEBUG_H

--- a/src/pocketdb/web/PocketRpc.cpp
+++ b/src/pocketdb/web/PocketRpc.cpp
@@ -76,6 +76,7 @@ static const CRPCCommand commands[] =
     {"contents",        "getnotifications",                 &GetNotifications,              {"height", "filters"}},
     {"contents",        "getnotificationssummary",          &GetNotificationsSummary,       {"addresses", "height", "filters"}},
     {"contents",        "getsubsciptionsgroupedbyauthors",  &GetsubsciptionsGroupedByAuthors, {"address", "addressPagination", "nHeight", "countOutOfUsers", "countOutOfcontents"}},
+    {"contents",        "getsubscribeschannels",            &GetSubscribesChannels,           {"address", "topHeight", "pageStart", "pageSize", "contentTypes"}},
 
     // Tags
 //    {"artifacts", "searchtags",                       &gettemplate,                       {"search_string", "count"}},


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- Added `getsubscribeschannels` RPC method to `PocketContentRpc`
- Implemented `WebRpcRepository::GetSubscribesChannels` — fetches channels (subscriptions) for a given address along with their latest content, paginated and filterable by content type
- Registered the new RPC handler in `PocketRpc.cpp`

## Other comments:

The method returns a list of channels the given address is subscribed to, enriched with the author's profile info (name, avatar) and their most recent content item up to the requested block height. Useful for building a personalised feed of followed channels.