### PR TITLE
Fix getsubscribeschannels params handling

### DIFF
--- a/src/pocketdb/web/PocketContentRpc.cpp
+++ b/src/pocketdb/web/PocketContentRpc.cpp
@@ -1673,7 +1673,7 @@ namespace PocketWeb::PocketWebRpc
                           "\nReturns subscriptions list with last content for each author (channel-style feed).\n",
                           {
                                   {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "User address whose subscriptions to fetch"},
-                                  {"topHeight", RPCArg::Type::NUM, RPCArg::Optional::NO, "Top block height"},
+                                  {"topHeight", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Top block height (default: current chain height)"},
                                   {"pageStart", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Offset for pagination (default: 0)"},
                                   {"pageSize", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Number of records (default: 20, max: 50)"},
                                   {"contentTypes", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "Content types filter (default: [200,201,202,209,210])",
@@ -1691,14 +1691,16 @@ namespace PocketWeb::PocketWebRpc
                           },
                           [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
                           {
-                              if (request.params.empty() || request.params.size() < 2)
-                                  throw JSONRPCError(RPC_INVALID_PARAMS, "address and topHeight are required");
+                              if (request.params.empty())
+                                  throw JSONRPCError(RPC_INVALID_PARAMS, "address is required");
 
                               string address = request.params[0].get_str();
-                              int topHeight = request.params[1].get_int();
+                              int topHeight = ChainActiveSafeHeight();
+                              if (request.params.size() > 1 && request.params[1].isNum() && request.params[1].get_int() > 0)
+                                  topHeight = request.params[1].get_int();
                               int pageStart = 0;
                               int pageSize = 20;
-                              vector<int> contentTypes = {200, 201, 202, 209, 210};
+                              vector<int> contentTypes;
 
                               if (request.params.size() > 2 && request.params[2].isNum())
                                   pageStart = request.params[2].get_int();
@@ -1706,16 +1708,11 @@ namespace PocketWeb::PocketWebRpc
                               if (request.params.size() > 3 && request.params[3].isNum())
                                   pageSize = std::min(request.params[3].get_int(), 50);
 
-                              if (request.params.size() > 4 && request.params[4].isArray())
-                              {
-                                  contentTypes.clear();
-                                  UniValue ctArray = request.params[4].get_array();
-                                  for (unsigned int i = 0; i < ctArray.size(); i++)
-                                  {
-                                      if (ctArray[i].isNum())
-                                          contentTypes.push_back(ctArray[i].get_int());
-                                  }
-                              }
+                              if (request.params.size() > 4)
+                                  ParseRequestContentTypes(request.params[4], contentTypes);
+
+                              if (contentTypes.empty())
+                                  contentTypes = {200, 201, 202, 209, 210};
 
                               UniValue channels = request.DbConnection()->WebRpcRepoInst->GetSubscribesChannels(
                                       address, topHeight, pageStart, pageSize, contentTypes);


### PR DESCRIPTION
## Summary
- Use `ChainActiveSafeHeight()` when `topHeight` is 0 or omitted — consistent with other feed methods, fixes SQL timeout
- Use `ParseRequestContentTypes` for `contentTypes` param — supports string types (e.g. `"video"`) alongside numeric codes

## Test plan
- [x] Call `getsubscribeschannels` with `topHeight=0` — should use current chain height instead of 0
- [x] Call with `contentTypes` as string (`"video"`), number (`201`), and mixed array (`[200, "video"]`)
- [x] Call without `contentTypes` — should default to `[200, 201, 202, 209, 210]`