### PR TITLE
Fix node crash on Barteron offer with missing tag

### DIFF
--- a/src/eventloop.h
+++ b/src/eventloop.h
@@ -200,7 +200,11 @@ public:
                 }
                 catch (const std::exception& e)
                 {
-                    LogPrintf("%s event loop thread exception: %s", name.value_or(""), e.what());
+                    LogPrintf("%s event loop thread exception: %s\n", name.value_or(""), e.what());
+                }
+                catch (...)
+                {
+                    LogPrintf("%s event loop thread unknown exception (possibly UniValue)\n", name.value_or(""));
                 }
             }
         });

--- a/src/pocketdb/repositories/web/WebRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRepository.cpp
@@ -499,7 +499,7 @@ namespace PocketDb
                 select
                     cu.Uid as AccountId,
                     ct.Uid as OfferId,
-                    json_extract(p.String4, '$.t') as Tag
+                    coalesce(json_extract(p.String4, '$.t'), 0) as Tag
                 from
                     Chain ct
                 cross join

--- a/src/websocket/notifyprocessor.cpp
+++ b/src/websocket/notifyprocessor.cpp
@@ -51,6 +51,8 @@ void NotifyBlockProcessor::Process(std::pair<CBlock, CBlockIndex*> entry)
         return;
     }
 
+    try {
+
     const auto& block = entry.first;
     auto blockIndex = entry.second;
     auto blockHeight = blockIndex->nHeight;
@@ -501,4 +503,10 @@ void NotifyBlockProcessor::Process(std::pair<CBlock, CBlockIndex*> entry)
         }
     };
     m_WSConnections->Iterate(send);
+
+    } catch (const std::exception& e) {
+        LogPrintf("Error: NotifyBlockProcessor::Process - %s\n", e.what());
+    } catch (...) {
+        LogPrintf("Error: NotifyBlockProcessor::Process - unknown exception at height %d\n", entry.second->nHeight);
+    }
 }


### PR DESCRIPTION
## Summary
- Fix crash caused by Barteron offer transaction without `$.t` field (height 3806251)
- Use `coalesce(json_extract(p.String4, '$.t'), 0)` in `UpsertBarteronOffers` to default NULL tag to 0
- Add `catch(...)` to `QueueEventLoopThread` to prevent uncaught exceptions from crashing the node
- Wrap `NotifyBlockProcessor::Process` in try-catch for safety

## Root cause
A Barteron offer without `$.t` in its JSON payload caused an uncaught exception in the notification processor thread. The node crashed in a loop, triggering an IBD death spiral that halted the entire network.

## Test plan
- [x] Node passes block 3806251 without crash with API enabled
- [x] Node syncs fully and stays stable
- [x] Tested on SC104 with `0.22.21-rc` image