### PR TITLE
Fix macOS build workflow: update runner and certificate import

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,8 +273,10 @@ jobs:
           path: ./out/*
 
   deploy-binaries:
+    if: github.ref == 'refs/heads/0.22'
     needs: [ build-macos-arm64, build-macos-amd64, build-linux, build-windows ]
     runs-on: dev.core
+    environment: production
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.branch-name.outputs.ref_branch }}
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Install general dependencies
         run: brew install automake make libtool miniupnpc protobuf qrencode librsvg python-setuptools
       - name: Cache depends
@@ -169,7 +169,7 @@ jobs:
           security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain 
           security default-keychain -s build.keychain
           security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-          security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign -A
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
           /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime dist/Pocketcoin-Qt.app -v
       - name: Notarize App
@@ -198,29 +198,37 @@ jobs:
           path: ./out/*
 
   build-macos-amd64:
-    runs-on: macos-13
+    runs-on: macos-15
     needs: prepare
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Install general dependencies
         run: |
           brew install automake make miniupnpc protobuf qrencode librsvg python-setuptools berkeley-db@4
-          pip3 install setuptools
+      - name: Detect depends path
+        id: detect
+        run: |
+          DARWIN_VER=$(sw_vers -productVersion | cut -d. -f1)
+          HOST="x86_64-apple-darwin${DARWIN_VER}.0.0"
+          echo "host=$HOST" >> $GITHUB_OUTPUT
+          echo "Detected HOST: $HOST"
       - name: Cache depends
         id: cache-depends
         uses: actions/cache@v4
         with:
-          path: depends/x86_64-apple-darwin22.6.0
-          key: macos-amd64-depends-${{ hashFiles('depends/Makefile', 'depends/funcs.mk', 'depends/packages/**/*.mk') }}
+          path: depends/${{ steps.detect.outputs.host }}
+          key: macos-amd64-depends-${{ steps.detect.outputs.host }}-${{ hashFiles('depends/Makefile', 'depends/funcs.mk', 'depends/packages/**/*.mk') }}
           restore-keys: macos-amd64-depends-
       - name: Build depends
         if: steps.cache-depends.outputs.cache-hit != 'true'
-        run: cd depends && make && cd ..
+        run: cd depends && make HOST=${{ steps.detect.outputs.host }} -j4 && cd ..
       - name: Configure
         run: |
           ./autogen.sh
-          ./configure --prefix=$PWD/depends/x86_64-apple-darwin22.6.0
+          ./configure --prefix=$PWD/depends/${{ steps.detect.outputs.host }}
       - name: Make
         run: |
           make -j4
@@ -236,7 +244,7 @@ jobs:
           security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain 
           security default-keychain -s build.keychain
           security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-          security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign -A
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
           /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime dist/Pocketcoin-Qt.app -v
       - name: Notarize App

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,10 +211,10 @@ jobs:
       - name: Detect depends path
         id: detect
         run: |
-          DARWIN_VER=$(sw_vers -productVersion | cut -d. -f1)
+          DARWIN_VER=$(uname -r | cut -d. -f1)
           HOST="x86_64-apple-darwin${DARWIN_VER}.0.0"
           echo "host=$HOST" >> $GITHUB_OUTPUT
-          echo "Detected HOST: $HOST"
+          echo "Detected HOST: $HOST (Darwin kernel ${DARWIN_VER})"
       - name: Cache depends
         id: cache-depends
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Replace deprecated `macos-13` runner with `macos-15`
- Dynamically detect HOST for depends cross-compilation on new runner
- Add `-A` flag to certificate import to fix keychain access error
- Fix checkout ref for macOS jobs (was using undefined `steps.branch-name.outputs.ref_branch`)
- Remove deprecated `pip3 install setuptools`

## Test plan
- [ ] Run Build workflow on 0.22 branch after merge