### PR TITLE
Add getboostsbyaddress RPC: list content boosts for an address

### DIFF
--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -4063,8 +4063,10 @@ namespace PocketDb
 
         // -------------------- Totals per direction (respecting topHeight) --------------------
 
-        auto countBoosts = [&](const string& sql) -> int64_t {
+        // Returns {count, amount} where amount is the sum of boost values in satoshis.
+        auto countBoosts = [&](const string& sql) -> std::pair<int64_t, int64_t> {
             int64_t total = 0;
+            int64_t amount = 0;
             SqlTransaction(
                 __func__,
                 [&]() -> Stmt& {
@@ -4075,31 +4077,68 @@ namespace PocketDb
                 [&] (Stmt& stmt) {
                     stmt.Select([&](Cursor& cursor) {
                         if (cursor.Step())
+                        {
                             if (auto[ok, value] = cursor.TryGetColumnInt64(0); ok) total = value;
+                            if (auto[ok, value] = cursor.TryGetColumnInt64(1); ok) amount = value;
+                        }
                     });
                 }
             );
-            return total;
+            return {total, amount};
         };
 
         if (wantSent)
         {
-            totals.pushKV("sent", countBoosts(R"sql(
+            auto[cnt, amount] = countBoosts(R"sql(
                 with addr as ( select RowId as id from Registry where String = ? )
-                select count(*)
+                select
+                    count(*),
+                    coalesce(sum(
+                        (
+                            select sum(io.Value)
+                            from TxInputs i indexed by TxInputs_SpentTxId_Number_TxId
+                            cross join TxOutputs io indexed by TxOutputs_TxId_Number_AddressId
+                                on io.TxId = i.TxId and io.Number = i.Number
+                            where i.SpentTxId = tBoost.RowId
+                        )
+                        -
+                        (
+                            select sum(o.Value)
+                            from TxOutputs o indexed by TxOutputs_TxId_Number_AddressId
+                            where o.TxId = tBoost.RowId
+                        )
+                    ), 0)
                 from addr
                 cross join Transactions tBoost indexed by Transactions_Type_RegId1_RegId2_RegId3
                     on tBoost.Type in (208) and tBoost.RegId1 = addr.id
                 cross join Chain cb
                     on cb.TxId = tBoost.RowId and cb.Height <= ?
-            )sql"));
+            )sql");
+            totals.pushKV("sent", cnt);
+            totals.pushKV("sentAmount", ValueFromAmount(amount));
         }
 
         if (wantReceived)
         {
-            totals.pushKV("received", countBoosts(R"sql(
+            auto[cnt, amount] = countBoosts(R"sql(
                 with addr as ( select RowId as id from Registry where String = ? )
-                select count(*)
+                select
+                    count(*),
+                    coalesce(sum(
+                        (
+                            select sum(io.Value)
+                            from TxInputs i indexed by TxInputs_SpentTxId_Number_TxId
+                            cross join TxOutputs io indexed by TxOutputs_TxId_Number_AddressId
+                                on io.TxId = i.TxId and io.Number = i.Number
+                            where i.SpentTxId = tBoost.RowId
+                        )
+                        -
+                        (
+                            select sum(o.Value)
+                            from TxOutputs o indexed by TxOutputs_TxId_Number_AddressId
+                            where o.TxId = tBoost.RowId
+                        )
+                    ), 0)
                 from addr
                 cross join Transactions tContent indexed by Transactions_Type_RegId1_RegId2_RegId3
                     on tContent.Type in (200, 201, 202, 209, 210, 221) and tContent.RegId1 = addr.id
@@ -4109,7 +4148,9 @@ namespace PocketDb
                     on tBoost.Type in (208) and tBoost.RegId2 = tContent.RegId2
                 cross join Chain cb
                     on cb.TxId = tBoost.RowId and cb.Height <= ?
-            )sql"));
+            )sql");
+            totals.pushKV("received", cnt);
+            totals.pushKV("receivedAmount", ValueFromAmount(amount));
         }
 
         // -------------------- Page of boosts (selected direction(s)) --------------------

--- a/src/pocketdb/repositories/web/WebRpcRepository.cpp
+++ b/src/pocketdb/repositories/web/WebRpcRepository.cpp
@@ -4052,6 +4052,206 @@ namespace PocketDb
         return result;
     }
 
+    UniValue WebRpcRepository::GetBoostsByAddress(const string& address, int topHeight, const string& direction, int count, int offset)
+    {
+        UniValue result(UniValue::VOBJ);
+        UniValue boosts(UniValue::VARR);
+        UniValue totals(UniValue::VOBJ);
+
+        bool wantSent = (direction == "sent" || direction == "both");
+        bool wantReceived = (direction == "received" || direction == "both");
+
+        // -------------------- Totals per direction (respecting topHeight) --------------------
+
+        auto countBoosts = [&](const string& sql) -> int64_t {
+            int64_t total = 0;
+            SqlTransaction(
+                __func__,
+                [&]() -> Stmt& {
+                    auto& stmt = Sql(sql);
+                    stmt.Bind(address, topHeight);
+                    return stmt;
+                },
+                [&] (Stmt& stmt) {
+                    stmt.Select([&](Cursor& cursor) {
+                        if (cursor.Step())
+                            if (auto[ok, value] = cursor.TryGetColumnInt64(0); ok) total = value;
+                    });
+                }
+            );
+            return total;
+        };
+
+        if (wantSent)
+        {
+            totals.pushKV("sent", countBoosts(R"sql(
+                with addr as ( select RowId as id from Registry where String = ? )
+                select count(*)
+                from addr
+                cross join Transactions tBoost indexed by Transactions_Type_RegId1_RegId2_RegId3
+                    on tBoost.Type in (208) and tBoost.RegId1 = addr.id
+                cross join Chain cb
+                    on cb.TxId = tBoost.RowId and cb.Height <= ?
+            )sql"));
+        }
+
+        if (wantReceived)
+        {
+            totals.pushKV("received", countBoosts(R"sql(
+                with addr as ( select RowId as id from Registry where String = ? )
+                select count(*)
+                from addr
+                cross join Transactions tContent indexed by Transactions_Type_RegId1_RegId2_RegId3
+                    on tContent.Type in (200, 201, 202, 209, 210, 221) and tContent.RegId1 = addr.id
+                cross join Last lc
+                    on lc.TxId = tContent.RowId
+                cross join Transactions tBoost indexed by Transactions_Type_RegId2_RegId1
+                    on tBoost.Type in (208) and tBoost.RegId2 = tContent.RegId2
+                cross join Chain cb
+                    on cb.TxId = tBoost.RowId and cb.Height <= ?
+            )sql"));
+        }
+
+        // -------------------- Page of boosts (selected direction(s)) --------------------
+
+        // Boosts made by the address (it spent coins to boost some content)
+        const string sqlSent = R"sql(
+            select
+                'sent' as direction,
+                (select r.String from Registry r where r.RowId = tBoost.RowId) as boostTxid,
+                addr.adr as boostAddress,
+                (
+                    select cr.String
+                    from Registry cr
+                    where cr.RowId = (
+                        select tc.RegId1
+                        from Transactions tc indexed by Transactions_Type_RegId2_RegId1
+                        where tc.Type in (200, 201, 202, 209, 210, 221) and tc.RegId2 = tBoost.RegId2
+                        limit 1
+                    )
+                ) as contentAddress,
+                (select r.String from Registry r where r.RowId = tBoost.RegId2) as contentTxid,
+                (
+                    (
+                        select sum(io.Value)
+                        from TxInputs i indexed by TxInputs_SpentTxId_Number_TxId
+                        cross join TxOutputs io indexed by TxOutputs_TxId_Number_AddressId
+                            on io.TxId = i.TxId and io.Number = i.Number
+                        where i.SpentTxId = tBoost.RowId
+                    )
+                    -
+                    (
+                        select sum(o.Value)
+                        from TxOutputs o indexed by TxOutputs_TxId_Number_AddressId
+                        where o.TxId = tBoost.RowId
+                    )
+                ) as boostAmount,
+                cb.Height as height,
+                tBoost.Time as time
+            from
+                addr
+            cross join
+                Transactions tBoost indexed by Transactions_Type_RegId1_RegId2_RegId3
+                    on tBoost.Type in (208) and tBoost.RegId1 = addr.id
+            cross join
+                Chain cb
+                    on cb.TxId = tBoost.RowId and cb.Height <= ?
+        )sql";
+
+        // Boosts received by the address (someone boosted content authored by the address)
+        const string sqlReceived = R"sql(
+            select
+                'received' as direction,
+                (select r.String from Registry r where r.RowId = tBoost.RowId) as boostTxid,
+                (select r.String from Registry r where r.RowId = tBoost.RegId1) as boostAddress,
+                addr.adr as contentAddress,
+                (select r.String from Registry r where r.RowId = tBoost.RegId2) as contentTxid,
+                (
+                    (
+                        select sum(io.Value)
+                        from TxInputs i indexed by TxInputs_SpentTxId_Number_TxId
+                        cross join TxOutputs io indexed by TxOutputs_TxId_Number_AddressId
+                            on io.TxId = i.TxId and io.Number = i.Number
+                        where i.SpentTxId = tBoost.RowId
+                    )
+                    -
+                    (
+                        select sum(o.Value)
+                        from TxOutputs o indexed by TxOutputs_TxId_Number_AddressId
+                        where o.TxId = tBoost.RowId
+                    )
+                ) as boostAmount,
+                cb.Height as height,
+                tBoost.Time as time
+            from
+                addr
+            cross join
+                Transactions tContent indexed by Transactions_Type_RegId1_RegId2_RegId3
+                    on tContent.Type in (200, 201, 202, 209, 210, 221) and tContent.RegId1 = addr.id
+            cross join
+                Last lc
+                    on lc.TxId = tContent.RowId
+            cross join
+                Transactions tBoost indexed by Transactions_Type_RegId2_RegId1
+                    on tBoost.Type in (208) and tBoost.RegId2 = tContent.RegId2
+            cross join
+                Chain cb
+                    on cb.TxId = tBoost.RowId and cb.Height <= ?
+        )sql";
+
+        string sql = R"sql(
+            with
+            addr as (
+                select RowId as id, String as adr
+                from Registry
+                where String = ?
+            )
+        )sql";
+        if (wantSent && wantReceived)
+            sql += sqlSent + " union all " + sqlReceived;
+        else if (wantSent)
+            sql += sqlSent;
+        else
+            sql += sqlReceived;
+        sql += " order by height desc, boostTxid desc limit ? offset ?";
+
+        SqlTransaction(
+            __func__,
+            [&]() -> Stmt& {
+                auto& stmt = Sql(sql);
+                stmt.Bind(address);
+                if (wantSent) stmt.Bind(topHeight);
+                if (wantReceived) stmt.Bind(topHeight);
+                stmt.Bind(count, offset);
+                return stmt;
+            },
+            [&] (Stmt& stmt) {
+                stmt.Select([&](Cursor& cursor) {
+                    while (cursor.Step())
+                    {
+                        UniValue record(UniValue::VOBJ);
+
+                        if (auto[ok, value] = cursor.TryGetColumnString(0); ok) record.pushKV("direction", value);
+                        if (auto[ok, value] = cursor.TryGetColumnString(1); ok) record.pushKV("txid", value);
+                        if (auto[ok, value] = cursor.TryGetColumnString(2); ok) record.pushKV("boostAddress", value);
+                        if (auto[ok, value] = cursor.TryGetColumnString(3); ok) record.pushKV("contentAddress", value);
+                        if (auto[ok, value] = cursor.TryGetColumnString(4); ok) record.pushKV("contentTxid", value);
+                        if (auto[ok, value] = cursor.TryGetColumnInt64(5); ok) record.pushKV("boostAmount", ValueFromAmount(value));
+                        if (auto[ok, value] = cursor.TryGetColumnInt(6); ok) record.pushKV("height", value);
+                        if (auto[ok, value] = cursor.TryGetColumnInt64(7); ok) record.pushKV("time", value);
+
+                        boosts.push_back(record);
+                    }
+                });
+            }
+        );
+
+        result.pushKV("height", topHeight);
+        result.pushKV("totals", totals);
+        result.pushKV("boosts", boosts);
+        return result;
+    }
+
     // ------------------------- Other ---------------------
 
     UniValue WebRpcRepository::SearchLinks(const vector<string>& links, const vector<int>& contentTypes, const int nHeight, const int countOut)

--- a/src/pocketdb/repositories/web/WebRpcRepository.h
+++ b/src/pocketdb/repositories/web/WebRpcRepository.h
@@ -168,6 +168,8 @@ namespace PocketDb
             const vector<string>& adrsExcluded, const vector<string>& tagsExcluded,
             int badReputationLimit);
 
+        UniValue GetBoostsByAddress(const string& address, int topHeight, const string& direction, int count, int offset);
+
         UniValue GetContentsStatistic(const vector<string>& addresses, const vector<int>& contentTypes);
 
         vector<int64_t> GetRandomContentIds(const string& lang, int count, int height);

--- a/src/pocketdb/web/PocketContentRpc.cpp
+++ b/src/pocketdb/web/PocketContentRpc.cpp
@@ -854,9 +854,11 @@ namespace PocketWeb::PocketWebRpc
                 {
                     RPCResult{RPCResult::Type::OBJ, "", "", {
                         {RPCResult::Type::NUM, "height", "Block height the selection was made for (boosts at height <= this value)"},
-                        {RPCResult::Type::OBJ, "totals", "Total number of matching boosts per direction (for pagination), ignoring count/offset", {
-                            {RPCResult::Type::NUM, "sent", /* optional */ true, "Total boosts made by the address (present when direction includes sent)"},
-                            {RPCResult::Type::NUM, "received", /* optional */ true, "Total boosts received on the address's content (present when direction includes received)"},
+                        {RPCResult::Type::OBJ, "totals", "Totals per direction (for pagination), ignoring count/offset", {
+                            {RPCResult::Type::NUM, "sent", /* optional */ true, "Total number of boosts made by the address (present when direction includes sent)"},
+                            {RPCResult::Type::NUM, "sentAmount", /* optional */ true, "Total amount of boosts made by the address, in PKOIN (present when direction includes sent)"},
+                            {RPCResult::Type::NUM, "received", /* optional */ true, "Total number of boosts received on the address's content (present when direction includes received)"},
+                            {RPCResult::Type::NUM, "receivedAmount", /* optional */ true, "Total amount of boosts received on the address's content, in PKOIN (present when direction includes received)"},
                         }},
                         {RPCResult::Type::ARR, "boosts", "", {
                             {RPCResult::Type::OBJ, "", "", {

--- a/src/pocketdb/web/PocketContentRpc.cpp
+++ b/src/pocketdb/web/PocketContentRpc.cpp
@@ -6,6 +6,7 @@
 #include "pocketdb/web/PocketContentRpc.h"
 #include "rpc/util.h"
 #include "validation.h"
+#include "util/html.h"
 #include "pocketdb/helpers/ShortFormModelsHelper.h"
 
 namespace PocketWeb::PocketWebRpc
@@ -835,6 +836,84 @@ namespace PocketWeb::PocketWebRpc
         result.pushKV("height", topHeight);
         result.pushKV("boosts", boosts);
         return result;
+    },
+        };
+    }
+
+    RPCHelpMan GetBoostsByAddress()
+    {
+        return RPCHelpMan{"getboostsbyaddress",
+                "\nReturns content boosts related to an address: boosts the address made and/or boosts received on the address's content.\n",
+                {
+                    {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "Account address to get boosts for"},
+                    {"topHeight", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Block height to search down from. 0 or omitted means current chain height (default 0)"},
+                    {"direction", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "Which boosts to return: \"sent\", \"received\" or \"both\" (default \"both\")"},
+                    {"count", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Max number of boosts to return (default 100, max 1000)"},
+                    {"offset", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Number of boosts to skip for pagination (default 0)"},
+                },
+                {
+                    RPCResult{RPCResult::Type::OBJ, "", "", {
+                        {RPCResult::Type::NUM, "height", "Block height the selection was made for (boosts at height <= this value)"},
+                        {RPCResult::Type::OBJ, "totals", "Total number of matching boosts per direction (for pagination), ignoring count/offset", {
+                            {RPCResult::Type::NUM, "sent", /* optional */ true, "Total boosts made by the address (present when direction includes sent)"},
+                            {RPCResult::Type::NUM, "received", /* optional */ true, "Total boosts received on the address's content (present when direction includes received)"},
+                        }},
+                        {RPCResult::Type::ARR, "boosts", "", {
+                            {RPCResult::Type::OBJ, "", "", {
+                                {RPCResult::Type::STR, "direction", "\"sent\" if the address made the boost, \"received\" if the address's content was boosted"},
+                                {RPCResult::Type::STR, "txid", "Boost transaction hash"},
+                                {RPCResult::Type::STR, "boostAddress", "Address that made the boost"},
+                                {RPCResult::Type::STR, "contentAddress", "Address that authored the boosted content"},
+                                {RPCResult::Type::STR, "contentTxid", "Hash of the boosted content"},
+                                {RPCResult::Type::NUM, "boostAmount", "Boost amount in PKOIN (decimal, satoshis / 1e8)"},
+                                {RPCResult::Type::NUM, "height", "Block height of the boost transaction"},
+                                {RPCResult::Type::NUM, "time", "Timestamp of the boost transaction"},
+                            }}
+                        }}
+                    }}
+                },
+                RPCExamples{
+                    HelpExampleCli("getboostsbyaddress", "\"1Pe6...\" 0 \"both\" 100 0") +
+                    HelpExampleRpc("getboostsbyaddress", "\"1Pe6...\", 0, \"both\", 100, 0")
+                },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+    {
+        RPCTypeCheck(request.params, {UniValue::VSTR});
+
+        string address = request.params[0].get_str();
+        if (address.empty())
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Parameter 'address' is required");
+
+        // 0 or omitted -> current chain height
+        int topHeight = ChainActiveSafeHeight();
+        if (request.params.size() > 1 && request.params[1].isNum() && request.params[1].get_int() > 0)
+            topHeight = request.params[1].get_int();
+
+        string direction = "both";
+        if (request.params.size() > 2 && request.params[2].isStr())
+        {
+            direction = request.params[2].get_str();
+            HtmlUtils::StringToLower(direction);
+            if (direction != "sent" && direction != "received" && direction != "both")
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Parameter 'direction' must be one of: sent, received, both");
+        }
+
+        int count = 100;
+        if (request.params.size() > 3 && request.params[3].isNum())
+        {
+            count = request.params[3].get_int();
+            if (count < 0) count = 0;
+            count = std::min(count, 1000);
+        }
+
+        int offset = 0;
+        if (request.params.size() > 4 && request.params[4].isNum())
+        {
+            offset = request.params[4].get_int();
+            if (offset < 0) offset = 0;
+        }
+
+        return request.DbConnection()->WebRpcRepoInst->GetBoostsByAddress(address, topHeight, direction, count, offset);
     },
         };
     }

--- a/src/pocketdb/web/PocketContentRpc.h
+++ b/src/pocketdb/web/PocketContentRpc.h
@@ -22,6 +22,7 @@ namespace PocketWeb::PocketWebRpc
     RPCHelpMan GetHistoricalFeed();
     RPCHelpMan GetHierarchicalFeed();
     RPCHelpMan GetBoostFeed();
+    RPCHelpMan GetBoostsByAddress();
     RPCHelpMan GetTopFeed();
     RPCHelpMan GetMostCommentedFeed();
     RPCHelpMan GetProfileFeed();

--- a/src/pocketdb/web/PocketRpc.cpp
+++ b/src/pocketdb/web/PocketRpc.cpp
@@ -60,6 +60,7 @@ static const CRPCCommand commands[] =
     {"contents",        "gethierarchicalfeed",              &GetHierarchicalFeed,           {"topHeight","topContentHash","countOut","lang","tags","contentTypes","txIdsExcluded","adrsExcluded","tagsExcluded","address"}},
     {"contents",        "gethierarchicalstrip",             &GetHierarchicalFeed,           {"topHeight","topContentHash","countOut","lang","tags","contentTypes","txIdsExcluded","adrsExcluded","tagsExcluded","address"}},
     {"contents",        "getboostfeed",                     &GetBoostFeed,                  {"topHeight","topContentHash","countOut","lang","tags","contentTypes","txIdsExcluded","adrsExcluded","tagsExcluded","address"}},
+    {"contents",        "getboostsbyaddress",               &GetBoostsByAddress,            {"address","topHeight","direction","count","offset"}},
     {"contents",        "gettopfeed",                       &GetTopFeed,                    {"topHeight","topContentHash","countOut","lang","tags","contentTypes","txIdsExcluded","adrsExcluded","tagsExcluded","address","depth"}},
     {"contents",        "getmostcommentedfeed",             &GetMostCommentedFeed,          {"topHeight","topContentHash","countOut","lang","tags","contentTypes","txIdsExcluded","adrsExcluded","tagsExcluded","address","depth"}},
     {"contents",        "getprofilefeed",                   &GetProfileFeed,                {"topHeight","topContentHash","countOut","lang","tags","contentTypes","txIdsExcluded","adrsExcluded","tagsExcluded","address","address_feed", "keyword"}},


### PR DESCRIPTION
## Summary

Adds a new `getboostsbyaddress` RPC method to the `contents` group that lists content boosts related to a given address.

## What it does

- Returns boosts **sent by** and **received for** the specified address
- Includes sent/received **amount totals in PKOIN**
- Supports pagination via `topHeight`

## Commits

- Add `getboostsbyaddress` RPC: list content boosts for an address
- `getboostsbyaddress`: add sent/received amount totals in PKOIN

## Notes

- Branched off `0.22`.
- Merge will be performed manually.